### PR TITLE
Accessors for the current drag target

### DIFF
--- a/src/Bloc.package/BlMouseProcessor.class/instance/currentDragTarget..st
+++ b/src/Bloc.package/BlMouseProcessor.class/instance/currentDragTarget..st
@@ -1,3 +1,3 @@
 accessing
-currentDragTarget: anObject
-	currentDragTarget := anObject
+currentDragTarget: anElementOrNil
+	currentDragTarget := anElementOrNil

--- a/src/Bloc.package/BlMouseProcessor.class/instance/currentDragTarget..st
+++ b/src/Bloc.package/BlMouseProcessor.class/instance/currentDragTarget..st
@@ -1,0 +1,3 @@
+accessing
+currentDragTarget: anObject
+	currentDragTarget := anObject

--- a/src/Bloc.package/BlMouseProcessor.class/instance/currentDragTarget.st
+++ b/src/Bloc.package/BlMouseProcessor.class/instance/currentDragTarget.st
@@ -1,0 +1,3 @@
+accessing
+currentDragTarget
+	^ currentDragTarget


### PR DESCRIPTION
Enabling things like

space := BlSpace new 
	extent: 800@600 ;
	yourself.
element := BlElement new 	
	size: 50@50;
	background: Color blue;
	addEventHandlerOn: BlDragStartEvent do: [ :evt | |drag handler|
			drag := BlElement new 	
				size: 50@50;
				background: Color random;
				yourself.
			handler := BlEventHandler on: BlDragEvent do: [ :evt2 |
				evt2 consumed: true.
				drag position: evt2 position ].
			drag addEventHandler: handler.
			drag addEventHandlerOn: BlDragEndEvent do: [ :evt2 |
				handler ifNotNil: [drag removeEventHandler: handler]. 
				handler := nil.
				evt2 consumed: true. ].
			space root addChild: drag.
			space mouseProcessor currentDragTarget: drag.
			evt consumed: true];
	yourself.
space root addChild:element.	
space show.