### PR TITLE
Fix cursor movement in BlTextEditListener

### DIFF
--- a/src/Bloc-Text-Elements.package/BlTextEditListener.class/instance/moveCursorLeft.by..st
+++ b/src/Bloc-Text-Elements.package/BlTextEditListener.class/instance/moveCursorLeft.by..st
@@ -5,14 +5,14 @@ moveCursorLeft: aTextEditElement by: aNumber
 
 	self
 		assert: [ aTextEditElement hasCursor ]
-		description: [ 'An element must have a cursor in order to move it right' ].
+		description: [ 'An element must have a cursor in order to move it left' ].
 
 	self 
 		assert: [ aNumber > 0 ]
 		description: [ 'Cursor movement distance must be greater than zero' ].
 	
-	(aTextEditElement cursorPosition - aNumber) <= 1
-		ifTrue: [ ^ self transferCursorRight: aTextEditElement ].
+	(aTextEditElement cursorPosition - aNumber) < 0
+		ifTrue: [ ^ self transferCursorLeft: aTextEditElement ].
 
 	self
 		moveCursorTo: aTextEditElement cursorPosition - aNumber


### PR DESCRIPTION
BlTextEditListener >> moveCursorLeft:by: refered to "right" in multiple places, probably from copying the method moveCursorRight:by:

The incorrect condition to transfer focus out of the element prevented the cursor from moving left of the second element.

Maybe I'm misunderstanding and this is actually correct and will break other stuff, but it seems odd.