### PR TITLE
BlOSWindowSDL2Renderer must destroy the renderer

### DIFF
--- a/src/BlocHost-OSWindow-SDL2/BlOSWindowSDL2Renderer.class.st
+++ b/src/BlocHost-OSWindow-SDL2/BlOSWindowSDL2Renderer.class.st
@@ -46,6 +46,12 @@ BlOSWindowSDL2Renderer >> canvasExtent [
 	^ extent
 ]
 
+{ #category : #deleting }
+BlOSWindowSDL2Renderer >> destroy [
+	renderer destroy.
+	super destroy.
+]
+
 { #category : #initialization }
 BlOSWindowSDL2Renderer >> initializeWindowHandle: aWindowHandle [
 


### PR DESCRIPTION
If the SDL_Renderer is not destroyed at this point, it will be destroyed by 
the finalization process (GC), when the SDL_Window was alrerady 
destroyed, which is detected by several asserts in the SDL library.

Thanks @tesonep for pair-programming.

Fixes #120 