### PR TITLE
Pass on pull handler

### DIFF
--- a/src/Bloc-PullAndSlide/BlPullEvent.class.st
+++ b/src/Bloc-PullAndSlide/BlPullEvent.class.st
@@ -1,56 +1,44 @@
+"
+I represent an intermediate pulling step, that begun with a `BlPullStartEvent` and will finish with a `BlPullEndEvent`.
+
+I know the initial position (in space) where the pull started, and the current position where the pull dragging is located.
+"
 Class {
 	#name : #BlPullEvent,
 	#superclass : #BlEvent,
 	#instVars : [
-		'initialPosition',
-		'oldPosition',
-		'newPosition',
-		'delta'
+		'initialDragPosition',
+		'currentDragPosition'
 	],
 	#category : #'Bloc-PullAndSlide-Events'
 }
 
 { #category : #accessing }
-BlPullEvent >> absoluteDelta [
-	^ self newPosition - self initialPosition
+BlPullEvent >> currentPosition [
+
+	^ currentDragPosition
 ]
 
 { #category : #accessing }
-BlPullEvent >> delta [
-	^ delta
+BlPullEvent >> currentPosition: aPoint [
+
+	currentDragPosition := aPoint
 ]
 
 { #category : #accessing }
-BlPullEvent >> delta: anObject [
-	delta := anObject
+BlPullEvent >> deltaFromInitialPosition [
+
+	^ currentDragPosition - initialDragPosition
 ]
 
 { #category : #accessing }
 BlPullEvent >> initialPosition [
-	^ initialPosition
+
+	^ initialDragPosition
 ]
 
 { #category : #accessing }
-BlPullEvent >> initialPosition: anObject [
-	initialPosition := anObject
-]
+BlPullEvent >> initialPosition: aPoint [
 
-{ #category : #accessing }
-BlPullEvent >> newPosition [
-	^ newPosition
-]
-
-{ #category : #accessing }
-BlPullEvent >> newPosition: anObject [
-	newPosition := anObject
-]
-
-{ #category : #accessing }
-BlPullEvent >> oldPosition [
-	^ oldPosition
-]
-
-{ #category : #accessing }
-BlPullEvent >> oldPosition: anObject [
-	oldPosition := anObject
+	initialDragPosition := aPoint
 ]

--- a/src/Bloc-PullAndSlide/BlPullHandler.class.st
+++ b/src/Bloc-PullAndSlide/BlPullHandler.class.st
@@ -1,14 +1,14 @@
 "
 I add an ability to drag (pull) any arbitrary element (the element which add myself as an event handler) within its direct parent by requesting position change.
 - Note 1: that some layout do not allow elements to have custom positions which means I have no effect.
-- Note 2: the moved element (the pull target) is by default the the element which add myself as an event handler. The relocated element can be explicitely setup with #pullTarget: (if the moved element is not the element which add myself as an eventDispatcher).
+- Note 2: the moved element (the pull target) is by default the element which add myself as an event handler. The relocated element can be explicitely setup with #pullTarget: (if the moved element is not the element which add myself as an eventDispatcher).
 
 The new position of the pulled target is computed as follow:
 - if I am setup as an horizontal handler, only the horizontal position is changed. 
 - if I am setup as a vertical handler, only the vertical position is changed
 
 By default, I change the location of the pulled object according to the dragging motion.
-But one can use relocateX: (relocateY:) to indicate if the abscissa (ordinate) of the pulled target is to be actually changed by myelf or not. As an example, the actual position of the pulled target can be changed externally as an effect of the dragging. In this case, relocateX: (relocateY:) can be used to indicate that this is not my responsibility to change the location of the abscissa (ordinate).
+But one can use relocateX: (relocateY:) to indicate if the abscissa (ordinate) of the pulled target is to be actually changed by myself or not. As an example, the actual position of the pulled target can be changed externally as an effect of the dragging. In this case, relocateX: (relocateY:) can be used to indicate that this is not my responsibility to change the location of the abscissa (ordinate).
 
 
 - Example 1
@@ -29,13 +29,11 @@ Class {
 	#name : #BlPullHandler,
 	#superclass : #BlCustomEventHandler,
 	#instVars : [
-		'dragStartGlobalPosition',
-		'originalPosition',
-		'allowedOutOfBounds',
 		'direction',
-		'pullTarget',
-		'relocateX',
-		'relocateY'
+		'allowOutOfBounds',
+		'dragStartPosition',
+		'target',
+		'initialTargetPosition'
 	],
 	#classVars : [
 		'Any',
@@ -54,9 +52,9 @@ BlPullHandler class >> initialize [
 
 { #category : #'api - pull handler' }
 BlPullHandler >> allowOutOfBounds [
-	"Allow the pulled element to be pulled outside of the parent bounds"
+	"Allow the pulled element to be pulled outside of the parent bounds."
 	
-	allowedOutOfBounds := true
+	allowOutOfBounds := true
 ]
 
 { #category : #'api - pull handler' }
@@ -77,78 +75,50 @@ BlPullHandler >> beVertical [
 	direction := Vertical
 ]
 
-{ #category : #'private - pulling' }
-BlPullHandler >> computePullDelta: aDragDelta [
-	
-	direction = Any
-		ifTrue: [ ^ aDragDelta ].
-		
-	direction = Vertical
-		ifTrue: [ ^ 0 @ aDragDelta y ].
-		
-	direction = Horizontal
-		ifTrue: [ ^ aDragDelta x @ 0 ].
-		
-	^ direction
-]
-
 { #category : #'api - pull handler' }
 BlPullHandler >> disallowOutOfBounds [
-	"Do not allow the pulled element to be pulled outside of the parent bounds"
+	"Do not allow the pulled element to be pulled outside of the parent bounds."
 	
-	allowedOutOfBounds := false
+	allowOutOfBounds := false
+]
+
+{ #category : #'event handling' }
+BlPullHandler >> dispatchPulledTo: currentPosition [
+
+	target dispatchEvent:
+		(BlPullEvent new
+			initialPosition: dragStartPosition;
+			currentPosition: currentPosition;
+			yourself)
 ]
 
 { #category : #'event handling' }
 BlPullHandler >> dragEndEvent: anEvent [
-	"anEvent consumed: true."
+
+	anEvent consumed: true.
 	
-	pullTarget dispatchEvent: BlPullEndEvent new
+	target dispatchEvent: BlPullEndEvent new
 ]
 
 { #category : #'event handling' }
-BlPullHandler >> dragEvent: anEvent [
+BlPullHandler >> dragEvent: aBlDragEvent [
 
-	| aStartPosition aCurrentPosition aPreviousPosition dragDelta aNewPosition newX newY |
-	dragStartGlobalPosition ifNil: [
-		dragStartGlobalPosition := anEvent position ].
+	| newPosition deltaFromStartPosition |
+	aBlDragEvent consumed: true.
 
-	aCurrentPosition :=
-		pullTarget globalPointToParentChildren: anEvent position.
-	aStartPosition :=
-		pullTarget globalPointToParentChildren: dragStartGlobalPosition.
+	deltaFromStartPosition := aBlDragEvent position - dragStartPosition.
+	newPosition := initialTargetPosition +
+		(self filteredDelta: deltaFromStartPosition).
+	
+	allowOutOfBounds ifFalse: [
+		| maxPosition |
+		maxPosition := target parent extent - target extent.
+		newPosition := newPosition min: maxPosition max: 0@0 ].
 
-	dragDelta := aCurrentPosition - aStartPosition.
-	dragDelta := (self computePullDelta: dragDelta) rounded.
+	newPosition := newPosition rounded.
+	target position: newPosition.
 
-	originalPosition ifNil: [
-		originalPosition := pullTarget constraints position ].
-
-	aNewPosition := originalPosition + dragDelta.
-	aPreviousPosition := pullTarget constraints position.
-	allowedOutOfBounds ifFalse: [
-		| aMaxPosition |
-		aMaxPosition := pullTarget hasParent
-			ifTrue: [
-				pullTarget parent extent - anEvent currentTarget extent ]
-			ifFalse: [ 0 @ 0 ].
-		aNewPosition := aNewPosition min: aMaxPosition max: 0 @ 0 ].
-
-	newX := relocateX
-		        ifTrue: [ aNewPosition x ]
-		        ifFalse: [ pullTarget constraints position x ].
-	newY := relocateY
-		        ifTrue: [ aNewPosition y ]
-		        ifFalse: [ pullTarget constraints position y ].
-	pullTarget position: newX @ newY.
-	anEvent consumed: true.
-
-	self
-		onPulled: pullTarget
-		from: aPreviousPosition
-		to: aNewPosition
-		by: dragDelta
-		starting: originalPosition
+	self dispatchPulledTo: newPosition
 ]
 
 { #category : #'event handling' }
@@ -156,67 +126,49 @@ BlPullHandler >> dragStartEvent: anEvent [
 
 	anEvent consumed: true.
 
-	pullTarget := pullTarget ifNil: [ anEvent currentTarget ].
-	pullTarget dispatchEvent: BlPullStartEvent new.
-
-	"drag start position in space coordinates"
-	dragStartGlobalPosition := anEvent position.
-
-	"element position in parent"
-	originalPosition := pullTarget constraints position
+	target ifNil: [ target := anEvent currentTarget ].
+	target dispatchEvent: BlPullStartEvent new.
+	
+	dragStartPosition := anEvent position.
+	initialTargetPosition := target position.
 ]
 
 { #category : #'api - accessing' }
 BlPullHandler >> eventsToHandle [
-	^ { BlDragStartEvent . BlDragEvent . BlDragEndEvent }
+
+	^ {		BlDragStartEvent.
+			BlDragEvent.
+			BlDragEndEvent }
+]
+
+{ #category : #private }
+BlPullHandler >> filteredDelta: aPoint [
+
+	direction = Vertical ifTrue: [ ^ 0 @ aPoint y ].
+	direction = Horizontal ifTrue: [ ^ aPoint x @ 0 ].
+	^ aPoint 	"direction = Any"
 ]
 
 { #category : #initialization }
 BlPullHandler >> initialize [
+
 	super initialize.
 	
-	allowedOutOfBounds := true.
-	direction := Any.
-	relocateX := true.
-	relocateY := true
-]
-
-{ #category : #'event handling' }
-BlPullHandler >> onPulled: aPulledElement from: aPreviousPosition to: aNewPosition by: aDragDelta starting: anOriginalPosition [
-
-	aPulledElement dispatchEvent:
-		(BlPullEvent new
-			initialPosition: anOriginalPosition;
-			oldPosition: aPreviousPosition;
-			newPosition: aNewPosition;
-			delta: aDragDelta;
-			yourself)
+	self allowOutOfBounds.
+	self beFree
 ]
 
 { #category : #accessing }
-BlPullHandler >> pullTarget [
+BlPullHandler >> target [
+	"Answer the element that is moved according to the dragging motion."
 
-	"the element which is moved according to the dragging motion"
-	^ pullTarget 
+	^ target
 ]
 
 { #category : #accessing }
-BlPullHandler >> pullTarget: anElement [
+BlPullHandler >> target: anElement [
+	"Set the element that is moved accordingly to the dragging motion. 
+	By default, this is the element that added myself as an event handler."
 
-	"Set the element which is moved according to the dragging motion. 
-	By default this is the element which add myself as an eventHandler "
-
-	pullTarget := anElement 
-]
-
-{ #category : #accessing }
-BlPullHandler >> relocateX: aBoolean [
-
-	relocateX := aBoolean
-]
-
-{ #category : #accessing }
-BlPullHandler >> relocateY: aBoolean [
-
-	relocateY := aBoolean
+	target := anElement 
 ]


### PR DESCRIPTION
* Pull handler:
  - remove relocateX and Y (was too confusing)
  - rename targetElement: to target: 
* BlPullEvent:
  - add class comment
  - full change in API: names were confusing, and not used. Now the event knows current position and initial position and seems to be fine.

Why? check the following users of this change:
- https://github.com/plantec/OnBloc/pull/4
- https://github.com/plantec/Toplo/pull/34
