### PR TITLE
Created a small Demo browser

### DIFF
--- a/src/Bloc-Demo/BlDemoApplication.class.st
+++ b/src/Bloc-Demo/BlDemoApplication.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #BlDemoApplication,
+	#superclass : #SpApplication,
+	#category : #'Bloc-Demo'
+}
+
+{ #category : #running }
+BlDemoApplication >> run [ 
+	(self new: BlDemoPresenter) open
+]

--- a/src/Bloc-Demo/BlDemoPresenter.class.st
+++ b/src/Bloc-Demo/BlDemoPresenter.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #SpPresenter,
 	#instVars : [
 		'transmissionPresenter',
-		'canva'
+		'canva',
+		'errorMessage'
 	],
 	#category : #'Bloc-Demo'
 }
@@ -33,9 +34,28 @@ BlDemoPresenter >> drawOnCanva: anElement [
 	| root |
 	root := self canva space root.
 	root removeChildren.
-	(anElement isKindOf: BlElement)
-		ifTrue: [ root addChild: anElement ]
-		ifFalse: [ ]
+	root addChild: ((anElement isKindOf: BlElement)
+		ifTrue: [ anElement ]
+		ifFalse: [ self errorMessage ])
+]
+
+{ #category : #accessing }
+BlDemoPresenter >> errorMessage [
+
+	^ errorMessage ifNil: [
+		  BlElement new
+			  background: Color lightRed;
+			  layout: BlFrameLayout new;
+			  constraintsDo: [ :c |
+				  c vertical matchParent.
+				  c horizontal matchParent ];
+			  addChild: (BlTextElement new
+					   text:
+						   'This method does not return any element for you to see'
+							   asRopedText;
+					   constraintsDo: [ :c |
+						   c frame vertical alignCenter.
+						   c frame horizontal alignCenter ]) ]
 ]
 
 { #category : #TOREMOVE }

--- a/src/Bloc-Demo/BlDemoPresenter.class.st
+++ b/src/Bloc-Demo/BlDemoPresenter.class.st
@@ -27,6 +27,17 @@ BlDemoPresenter >> defaultLayout [
 		yourself
 ]
 
+{ #category : #'as yet unclassified' }
+BlDemoPresenter >> drawOnCanva: anElement [
+
+	| root |
+	root := self canva space root.
+	root removeChildren.
+	(anElement isKindOf: BlElement)
+		ifTrue: [ root addChild: anElement ]
+		ifFalse: [ ]
+]
+
 { #category : #TOREMOVE }
 BlDemoPresenter >> initialExtent [
 

--- a/src/Bloc-Demo/BlDemoPresenter.class.st
+++ b/src/Bloc-Demo/BlDemoPresenter.class.st
@@ -1,0 +1,74 @@
+Class {
+	#name : #BlDemoPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'transmissionPresenter',
+		'canva'
+	],
+	#category : #'Bloc-Demo'
+}
+
+{ #category : #accessing }
+BlDemoPresenter >> canva [ 
+	^ canva 
+]
+
+{ #category : #accessing }
+BlDemoPresenter >> canva: aCanva [
+	canva := aCanva 
+]
+
+{ #category : #layout }
+BlDemoPresenter >> defaultLayout [
+	^ SpPanedLayout newLeftToRight 
+		positionOfSlider: 600;
+		add: transmissionPresenter;
+		add: canva;
+		yourself
+]
+
+{ #category : #TOREMOVE }
+BlDemoPresenter >> initialExtent [
+
+	| fontWidth rowHeight |
+	fontWidth := (StandardFonts defaultFont widthOfString: 'M').
+	rowHeight := self class inputTextHeight.
+
+	^ (90@24) * (fontWidth @ rowHeight)
+	
+]
+
+{ #category : #initialization }
+BlDemoPresenter >> initializeCanvaPresenter [ 
+	
+	canva := SpBlSpaceInMorphPresenter new
+]
+
+{ #category : #initialization }
+BlDemoPresenter >> initializePresenters [
+
+	self initializeTransmissionPresenter.
+	self initializeCanvaPresenter.
+	
+]
+
+{ #category : #initialization }
+BlDemoPresenter >> initializeTransmissionPresenter [ 
+
+	transmissionPresenter := BlDemoTransmissionPresenter new
+]
+
+{ #category : #TOREMOVE }
+BlDemoPresenter >> title [ 
+	^ 'Bloc UI Framework Demo'
+]
+
+{ #category : #accessing }
+BlDemoPresenter >> transmissionPresenter [ 
+	^ transmissionPresenter 
+]
+
+{ #category : #accessing }
+BlDemoPresenter >> transmissionPresenter: aPresenter [
+	transmissionPresenter := aPresenter 
+]

--- a/src/Bloc-Demo/BlDemoTransmissionPresenter.class.st
+++ b/src/Bloc-Demo/BlDemoTransmissionPresenter.class.st
@@ -11,6 +11,11 @@ Class {
 }
 
 { #category : #accessing }
+BlDemoTransmissionPresenter >> classes [ 
+	^ classes
+]
+
+{ #category : #accessing }
 BlDemoTransmissionPresenter >> code [ 
 	^ code
 ]
@@ -100,12 +105,23 @@ BlDemoTransmissionPresenter >> defaultLayout [
 		yourself
 ]
 
+{ #category : #'as yet unclassified' }
+BlDemoTransmissionPresenter >> executeCode [
+
+	| class method res |
+	class := self classes selectedItem.
+	method := self methods selectedItem.
+	res := class new perform: method selector asSymbol.
+	self owner drawOnCanva: res
+]
+
 { #category : #initialization }
 BlDemoTransmissionPresenter >> initializeClassesPresenter [
 
 	classes := self newList.
-	classes items: BlExampleTest allSubclasses ;
-		display: [ :class | class name];
+	classes
+		items: self itemsClasses;
+		display: [ :class | class name ];
 		displayIcon: [ :aClass | self iconNamed: aClass systemIconName ];
 		sortingBlock: [ :a :b | a name < b name ]
 ]
@@ -123,7 +139,7 @@ BlDemoTransmissionPresenter >> initializeMethodsPresenter [
 	methods
 		display: [ :method | method selector ];
 		sortingBlock: [ :a :b | a selector < b selector ];
-		whenSelectedDo: [ :i | methods inspect ]
+		whenSelectedDo: [ :i | self executeCode ]
 ]
 
 { #category : #initialization }
@@ -141,6 +157,12 @@ BlDemoTransmissionPresenter >> initializeProtocolsPresenter [
 	protocols
 		display: [ :aPair | aPair value name ];
 		sortingBlock: [ :a :b | a value name < b value name ]
+]
+
+{ #category : #'as yet unclassified' }
+BlDemoTransmissionPresenter >> itemsClasses [
+
+	^ BlExampleTest allSubclasses  
 ]
 
 { #category : #accessing }

--- a/src/Bloc-Demo/BlDemoTransmissionPresenter.class.st
+++ b/src/Bloc-Demo/BlDemoTransmissionPresenter.class.st
@@ -1,0 +1,150 @@
+Class {
+	#name : #BlDemoTransmissionPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'classes',
+		'protocols',
+		'methods',
+		'code'
+	],
+	#category : #'Bloc-Demo'
+}
+
+{ #category : #accessing }
+BlDemoTransmissionPresenter >> code [ 
+	^ code
+]
+
+{ #category : #initialization }
+BlDemoTransmissionPresenter >> connectClassesPresenter [
+
+	classes
+		transmitTo: protocols
+		transform: [ :aClass | 
+			aClass
+				ifNotNil: [ 
+					aClass organization protocols
+						collect: [ :each | aClass -> each ]
+						as: OrderedCollection ]
+				ifNil: [ #(  ) ] ]
+		postTransmission: [ :destination :origin | destination selectIndex: 1 ].
+	
+	classes
+		transmitTo: code
+		transform: [ :aClass | aClass ifNotNil: [ aClass definitionString ] ifNil: [ '' ] ]
+]
+
+{ #category : #initialization }
+BlDemoTransmissionPresenter >> connectMethodsPresenter [
+
+	methods
+		transmitTo: code  
+		transform: [ :aMethod | aMethod ifNotNil: [ aMethod sourceCode ] ifNil: [ '' ] ].
+	SystemAnnouncer uniqueInstance weak when: MethodModified do: [ :evt |
+    evt traceCr ]
+]
+
+{ #category : #initialization }
+BlDemoTransmissionPresenter >> connectPresenters [
+
+	self connectClassesPresenter.
+	self connectProtocolsPresenter.
+	self connectMethodsPresenter
+]
+
+{ #category : #initialization }
+BlDemoTransmissionPresenter >> connectProtocolsPresenter [
+
+	protocols
+		transmitTo: methods
+		transform: [ :aPair | 
+			aPair
+				ifNotNil: [ 
+					aPair value methodSelectors
+						collect: [ :each | aPair key >> each ]
+						as: OrderedCollection ]
+				ifNil: [ #(  ) ] ].
+			
+	protocols
+		transmitTo: code
+		transform: [ :aPair | aPair ifNotNil: [ aPair key sourceCodeTemplate ] ifNil: [ '' ] ]
+]
+
+{ #category : #layout }
+BlDemoTransmissionPresenter >> defaultLayout [
+
+	|  classesLayout protocolsLayout methodsLayout |
+	
+	classesLayout := SpBoxLayout newTopToBottom
+		add: 'Classes' expand: false;
+		add: classes;
+		yourself.
+		
+	protocolsLayout := SpBoxLayout newTopToBottom
+		add: 'Protocols' expand: false;
+		add: protocols;
+		yourself.
+		
+	methodsLayout := SpBoxLayout newTopToBottom
+		add: 'Methods' expand: false;
+		add: methods;
+		yourself.
+		
+	^ SpBoxLayout newTopToBottom
+		spacing: 5;
+		add: (SpBoxLayout newLeftToRight
+			spacing: 5;
+			add: classesLayout;
+			add: protocolsLayout;
+			add: methodsLayout;
+			yourself);	
+		add: code;
+		yourself
+]
+
+{ #category : #initialization }
+BlDemoTransmissionPresenter >> initializeClassesPresenter [
+
+	classes := self newList.
+	classes items: BlExampleTest allSubclasses ;
+		display: [ :class | class name];
+		displayIcon: [ :aClass | self iconNamed: aClass systemIconName ];
+		sortingBlock: [ :a :b | a name < b name ]
+]
+
+{ #category : #initialization }
+BlDemoTransmissionPresenter >> initializeCodePresenter [
+
+	code := self newCode.
+]
+
+{ #category : #initialization }
+BlDemoTransmissionPresenter >> initializeMethodsPresenter [
+
+	methods := self newList.
+	methods
+		display: [ :method | method selector ];
+		sortingBlock: [ :a :b | a selector < b selector ]
+]
+
+{ #category : #initialization }
+BlDemoTransmissionPresenter >> initializePresenters [ 
+	self initializeClassesPresenter.
+	self initializeProtocolsPresenter.
+	self initializeMethodsPresenter.
+	self initializeCodePresenter 
+]
+
+{ #category : #initialization }
+BlDemoTransmissionPresenter >> initializeProtocolsPresenter [
+
+	protocols := self newList.
+	protocols
+		display: [ :aPair | aPair value name ];
+		sortingBlock: [ :a :b | a value name < b value name ]
+]
+
+{ #category : #accessing }
+BlDemoTransmissionPresenter >> methods [ 
+	^ methods
+]

--- a/src/Bloc-Demo/BlDemoTransmissionPresenter.class.st
+++ b/src/Bloc-Demo/BlDemoTransmissionPresenter.class.st
@@ -40,8 +40,6 @@ BlDemoTransmissionPresenter >> connectMethodsPresenter [
 	methods
 		transmitTo: code  
 		transform: [ :aMethod | aMethod ifNotNil: [ aMethod sourceCode ] ifNil: [ '' ] ].
-	SystemAnnouncer uniqueInstance weak when: MethodModified do: [ :evt |
-    evt traceCr ]
 ]
 
 { #category : #initialization }
@@ -124,7 +122,8 @@ BlDemoTransmissionPresenter >> initializeMethodsPresenter [
 	methods := self newList.
 	methods
 		display: [ :method | method selector ];
-		sortingBlock: [ :a :b | a selector < b selector ]
+		sortingBlock: [ :a :b | a selector < b selector ];
+		whenSelectedDo: [ :i | methods inspect ]
 ]
 
 { #category : #initialization }

--- a/src/Bloc-Demo/package.st
+++ b/src/Bloc-Demo/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Bloc-Demo' }


### PR DESCRIPTION
Hello, 

I wanted to try and create a Demo Browser with Spec2. It aims to display some example classes you can browse and display their methods code while showing the graphical result in a Space nearby. Here's a screenshot : 

<img width="1013" alt="Capture d’écran 2023-11-03 à 13 52 26" src="https://github.com/pharo-graphics/Bloc/assets/121249182/16002234-a7cb-424c-8389-4021288683a2">

The Demo Browser can be opened executing 
```smalltalk 
BlDemoPresenter new open
```

I think this could be a great addition to Bloc and I would have loved having this at the beginning to understand Bloc basics.

This is the very first iteration as it is my first project with Spec2 but I'm proud of it. Also I wanted to share it early so this could be improved in early development. 

For now it browses through `BlExampleTest` subclasses as I saw most of available examples inherits this class but many methods return objects that are not `BlElement` so for now, for those methods, the browser displays a small text (see below) 

<img width="992" alt="Capture d’écran 2023-11-03 à 14 00 52" src="https://github.com/pharo-graphics/Bloc/assets/121249182/0baa3827-223e-4775-9e5e-7cd63c8a7275">
 
Here's a list of things that I know aren't working right now : 
- methods that require at least one argument (but if we later focus on example scripts this should not be a concern)
- animations (due to a `repeats` message in some methods) 

There might be a lot of other problems in other methods but I suppose it is because I took all BlExampleTest subclasses, maybe create a package with only scripts or filter using pragmas could be a reasonable choice.