### PR TITLE
Little cleaning of BlCompositeBackground

### DIFF
--- a/src/Bloc-Alexandrie/BlCompositeBackground.extension.st
+++ b/src/Bloc-Alexandrie/BlCompositeBackground.extension.st
@@ -3,6 +3,6 @@ Extension { #name : #BlCompositeBackground }
 { #category : #'*Bloc-Alexandrie' }
 BlCompositeBackground >> aeApplyTo: aeCanvas [
 	"Draw all backgrounds in add order"
-	
-	backgrounds do:[ :b | b aeApplyTo: aeCanvas ].
+
+	self backgrounds do: [ :background | background aeApplyTo: aeCanvas ]
 ]

--- a/src/Bloc/BlCompositeBackground.class.st
+++ b/src/Bloc/BlCompositeBackground.class.st
@@ -1,27 +1,30 @@
 "
-I provide composition ability of multiple `=BlBackground`=.
+I provide composition ability of multiple `BlBackground`.
 I am useful when an Element should have both paint and image backgrounds.
 
 Note: composed backgrounds are rendered in the same order they are defined in a composition. So for example if I was created as follows:
 
+```
 BlCompositeBackground withAll: {
 	BlPaintBackground paint: Color red.
 	BlImageBackground image: PolymorphSystemSettings pharoLogoForm
 } 
+```
 
-then image background will appear on top of paint background.
+Then image background will appear on top of paint background.
 
-It is more convenient to create a composite background using `=BlBackgroundBuilder`=
+It is more convenient to create a composite background using `BlBackgroundBuilder`.
 
 Opacity example:
 
+```
 	BlCompositeBackground new
 		opacity: 0.5;
 		withAll: {
 			BlPaintBackground paint: Color red.
 			BlImageBackground image: PolymorphSystemSettings pharoLogoForm
 		} 
-
+```
 "
 Class {
 	#name : #BlCompositeBackground,
@@ -34,6 +37,7 @@ Class {
 
 { #category : #'instance creation' }
 BlCompositeBackground class >> withAll: aCollectionOfBackground [
+
 	^ self new withAll: aCollectionOfBackground
 ]
 
@@ -44,22 +48,15 @@ BlCompositeBackground >> backgrounds [
 	^ backgrounds
 ]
 
-{ #category : #initialization }
-BlCompositeBackground >> initialize [
-
-	super initialize.
-	backgrounds := Array new
-]
-
 { #category : #testing }
 BlCompositeBackground >> isTransparent [
 
-	^ (self opacity closeTo: 0.0) or: [ backgrounds allSatisfy: #isTransparent ]
+	^ (self opacity closeTo: 0.0) or: [ self backgrounds allSatisfy: #isTransparent ]
 ]
 
 { #category : #geometry }
 BlCompositeBackground >> matchExtent: anExtent [
-	backgrounds do: [ :aBackground | aBackground matchExtent: anExtent ]
+	self backgrounds do: [ :aBackground | aBackground matchExtent: anExtent ]
 ]
 
 { #category : #initialization }
@@ -67,5 +64,7 @@ BlCompositeBackground >> withAll: aCollectionOfBackgrounds [
 	"Return a composite background based on the collection of background pass as argument. 
 	This collection of backgrounds must not be empty"
 
-	backgrounds := aCollectionOfBackgrounds asArray copy
+	backgrounds := aCollectionOfBackgrounds isArray
+		               ifTrue: [ aCollectionOfBackgrounds copy ]
+		               ifFalse: [ aCollectionOfBackgrounds asArray ]
 ]


### PR DESCRIPTION
This change cleans a little BlCompositeBackground

- Avoid to copy collections twice in #withAll:
- Do not initialize with an empty collection since all users are updating this collection later
- Use getter
- Remove an abbreviation to use something more readable
- Improve the rendering of the class comment

Fixes #366