### PR TITLE
Deprecate with transform rule some BlSpace methods that only forward to root element

### DIFF
--- a/src/Bloc/BlSpace.class.st
+++ b/src/Bloc/BlSpace.class.st
@@ -507,6 +507,10 @@ BlSpace >> center [
 { #category : #'children - accessing' }
 BlSpace >> children [
 
+	self
+		deprecated: 'Talk directly to root'
+		transformWith: '`@rcv children' -> '`@rcv root children'.
+		
 	^ self root children
 ]
 
@@ -527,7 +531,10 @@ BlSpace >> close [
 { #category : #'composition layer' }
 BlSpace >> compositionLayer [
 	"Return my composition layer if I have one or nil otherwise"
-	<return: #BlCompositionLayer or: nil>
+
+	self
+		deprecated: 'Talk directly to root'
+		transformWith: '`@rcv compositionLayer' -> '`@rcv root compositionLayer'.
 
 	^ self root compositionLayer
 ]
@@ -1702,6 +1709,11 @@ BlSpace >> toFront [
 
 { #category : #accessing }
 BlSpace >> topMostParent [
+
+	self
+		deprecated: 'Talk directly to root'
+		transformWith: '`@rcv topMostParent' -> '`@rcv root'.
+
 	^ self root
 ]
 
@@ -1779,13 +1791,20 @@ BlSpace >> windowScale [
 
 { #category : #'api - children enumeration' }
 BlSpace >> withAllChildrenBreadthFirst [
-	<return: #Collection of: #BlElement>
+
+	self
+		deprecated: 'Talk directly to root'
+		transformWith: '`@rcv withAllChildrenBreadthFirst' -> '`@rcv root withAllChildrenBreadthFirst'.
 	
 	^ self root withAllChildrenBreadthFirst
 ]
 
 { #category : #'api - children enumeration' }
 BlSpace >> withAllChildrenBreadthFirstDo: aBlock [ 
-	
+
+	self
+		deprecated: 'Talk directly to root'
+		transformWith: '`@rcv withAllChildrenBreadthFirstDo: `@arg' -> '`@rcv root withAllChildrenBreadthFirstDo: `@arg'.
+
 	^ self root withAllChildrenBreadthFirstDo: aBlock 
 ]


### PR DESCRIPTION

Fix #435

Tested with:
```smalltalk
{  BlSpace>>#withAllChildrenBreadthFirstDo:.
	BlSpace>>#withAllChildrenBreadthFirst.
	BlSpace>>#topMostParent.
	BlSpace>>#compositionLayer.
	BlSpace>>#children.
} collect: [:deprecatedMethod |
	testClass := ((Object << ('TestDeprecate', deprecatedMethod identityHash hex)) package: 'MyPackage') install.
	testSelector := #m.

	src := String streamContents: [ :stream |
		stream
			<< testSelector;
			<< ' ';
			<< deprecatedMethod origin name;
			<< ' basicNew '.
		deprecatedMethod selector isUnary
			ifTrue: [
				stream << deprecatedMethod selector ]
			ifFalse: [
				deprecatedMethod selector keywords do: [ :each |
					stream
						<< each;
						<< ' nil ' ] ] ].
	testClass compile: src.

	testMethod := testClass >> testSelector.
	self assert: testMethod sourceCode = src.

	[ testClass new perform: testSelector ] onErrorDo: [:e |
		"It's normal to get errors since the receiver is not
		preperly initialized, and it may receive nils as arguments."].

	testMethod := testClass >> testSelector.
	newSrc := testMethod sourceCode.
	self assert: newSrc ~= src.

	{ src. newSrc }.
]
```
