### PR TITLE
Make #physicalSize on BlMorphicHostSpace apply the world renderer canvas scale factor

### DIFF
--- a/src/BlocHost-Morphic/BlMorphicHostSpace.class.st
+++ b/src/BlocHost-Morphic/BlMorphicHostSpace.class.st
@@ -123,7 +123,12 @@ BlMorphicHostSpace >> physicalSize [
 	This size may differ from the logical size on high dpi (retina) screens.
 	In most cases physical size is x2 larger than logical size on retina screens."
 
-	^ ((spaceHostMorph width @ spaceHostMorph height) * OSWorldRenderer canvasScaleFactor) asPhysicalSize
+	| canvasScaleFactor |
+
+	canvasScaleFactor := SystemVersion current major >= 12
+		ifTrue: [ (Smalltalk at: #OSWorldRenderer) canvasScaleFactor ]
+		ifFalse: [ 1 ].
+	^ ((spaceHostMorph width @ spaceHostMorph height) * canvasScaleFactor) asPhysicalSize
 ]
 
 { #category : #'window - properties' }

--- a/src/BlocHost-Morphic/BlMorphicHostSpace.class.st
+++ b/src/BlocHost-Morphic/BlMorphicHostSpace.class.st
@@ -123,7 +123,7 @@ BlMorphicHostSpace >> physicalSize [
 	This size may differ from the logical size on high dpi (retina) screens.
 	In most cases physical size is x2 larger than logical size on retina screens."
 
-	^ (spaceHostMorph width @ spaceHostMorph height) asPhysicalSize
+	^ ((spaceHostMorph width @ spaceHostMorph height) * OSWorldRenderer canvasScaleFactor) asPhysicalSize
 ]
 
 { #category : #'window - properties' }

--- a/src/BlocHost-Morphic/BlMorphicSpaceHostMorph.class.st
+++ b/src/BlocHost-Morphic/BlMorphicSpaceHostMorph.class.st
@@ -23,7 +23,12 @@ BlMorphicSpaceHostMorph >> drawOn: aCanvas [
 		ifTrue: [ ^ self ].
 	hostSpace ifNotNil: [ 
 		aCanvas clipBy: self fullBounds during: [ :aClippedCanvas |
-			aClippedCanvas drawFormSet: (FormSet extent: self extent depth: spaceForm depth forms: { spaceForm }) at: self position ] ]
+			SystemVersion current major >= 12 ifTrue: [
+				| formSet |
+				formSet := (Smalltalk at: #FormSet) extent: self extent depth: spaceForm depth forms: { spaceForm }.
+				aClippedCanvas drawFormSet: formSet at: self position
+			] ifFalse: [
+				aClippedCanvas drawImage: spaceForm at: self position ] ] ]
 ]
 
 { #category : #geometry }

--- a/src/BlocHost-Morphic/BlMorphicSpaceHostMorph.class.st
+++ b/src/BlocHost-Morphic/BlMorphicSpaceHostMorph.class.st
@@ -23,7 +23,7 @@ BlMorphicSpaceHostMorph >> drawOn: aCanvas [
 		ifTrue: [ ^ self ].
 	hostSpace ifNotNil: [ 
 		aCanvas clipBy: self fullBounds during: [ :aClippedCanvas |
-			aClippedCanvas drawImage: spaceForm at: self position ] ]
+			aClippedCanvas drawFormSet: (FormSet extent: self extent depth: spaceForm depth forms: { spaceForm }) at: self position ] ]
 ]
 
 { #category : #geometry }


### PR DESCRIPTION
This pull request makes `#physicalSize` on BlMorphicHostSpace apply the world renderer canvas scale factor. For details see issue #450.

Note that this pull request depends on changes in Pharo 12, specifically the class FormSet introduced in [Pharo pull request #14998](https://github.com/pharo-project/pharo/pull/14998) and the method `#canvasScaleFactor` for OSWorldRenderer introduced in [Pharo pull request #15647](https://github.com/pharo-project/pharo/pull/15647).