### PR TITLE
Deprecate BlDelayPulsesTask since it's not used and its purpose was debugging

### DIFF
--- a/src/Bloc/BlDelayPulsesTask.class.st
+++ b/src/Bloc/BlDelayPulsesTask.class.st
@@ -27,6 +27,13 @@ Class {
 	#category : #'Bloc-Space - Tasks'
 }
 
+{ #category : #testing }
+BlDelayPulsesTask class >> isDeprecated [
+	"Deprecated only because it is not used and its purpose was debugging."
+
+	^ true
+]
+
 { #category : #accessing }
 BlDelayPulsesTask >> count [
 	^ count


### PR DESCRIPTION
See https://github.com/pharo-graphics/Bloc/pull/482