### PR TITLE
Add convenience objects to use taskit in Bloc

### DIFF
--- a/src/Bloc-Taskit-Tests/TKTBlocExamples.class.st
+++ b/src/Bloc-Taskit-Tests/TKTBlocExamples.class.st
@@ -7,6 +7,13 @@ Class {
 { #category : #examples }
 TKTBlocExamples >> runnerExample [
 	<sampleInstance>
+"  This is equivalent to:
+	space
+		enqueueTask:
+			(BlRepeatedTaskAction new
+				delay: 200 milliSeconds;
+				action: [ space root background: Color random ];
+				yourself)."
 
 	| space runner |
 	space := BlSpace new.
@@ -19,23 +26,21 @@ TKTBlocExamples >> runnerExample [
 	[	17 timesRepeat: [
 			runner schedule: [
 				space root background: Color random ] asTask.
-			250 milliSeconds wait ].
+			200 milliSeconds wait ] ] fork.
 
-		runner stop.
-		space close ] fork
-
-"  We kind of emulate this:
-	space
-		enqueueTask:
-			(BlRepeatedTaskAction new
-				delay: 250 milliSeconds;
-				action: [ space root background: Color random ];
-				yourself)."
+	^ space
 ]
 
 { #category : #examples }
 TKTBlocExamples >> serviceExample [
 	<sampleInstance>
+	"This example is equivalent to:
+	space
+		enqueueTask:
+			(BlRepeatedTaskAction new
+				delay: 100 milliSeconds;
+				action: [ space root background: Color random ];
+				yourself)."
 
 	| space service |
 	space := BlSpace new.
@@ -44,20 +49,12 @@ TKTBlocExamples >> serviceExample [
 		show.
 
 	service := TKTBlSpaceService on: space.
-
 	service step: [ space root background: Color random ].
-	service stepDelay:	250 milliSeconds.
+	service stepDelay: 100 milliSeconds.
 	service start.
-	
-	[  3 seconds wait.
-		service stop.
-		space close ] fork
 
-"  We kind of emulate this:
-	space
-		enqueueTask:
-			(BlRepeatedTaskAction new
-				delay: 250 milliSeconds;
-				action: [ space root background: Color random ];
-				yourself)."
+	[	2 seconds wait.
+		service stop waitForCompletion: 1 second ] fork.
+	
+	^ space
 ]

--- a/src/Bloc-Taskit-Tests/TKTBlocExamples.class.st
+++ b/src/Bloc-Taskit-Tests/TKTBlocExamples.class.st
@@ -1,0 +1,63 @@
+Class {
+	#name : #TKTBlocExamples,
+	#superclass : #BlExamplesTest,
+	#category : #'Bloc-Taskit-Tests'
+}
+
+{ #category : #examples }
+TKTBlocExamples >> runnerExample [
+	<sampleInstance>
+
+	| space runner |
+	space := BlSpace new.
+	space
+		extent: 100@100;
+		show.
+
+	runner := TKTBlSpaceRunner on: space.
+
+	[	17 timesRepeat: [
+			runner schedule: [
+				space root background: Color random ] asTask.
+			250 milliSeconds wait ].
+
+		runner stop.
+		space close ] fork
+
+"  We kind of emulate this:
+	space
+		enqueueTask:
+			(BlRepeatedTaskAction new
+				delay: 250 milliSeconds;
+				action: [ space root background: Color random ];
+				yourself)."
+]
+
+{ #category : #examples }
+TKTBlocExamples >> serviceExample [
+	<sampleInstance>
+
+	| space service |
+	space := BlSpace new.
+	space
+		extent: 100@100;
+		show.
+
+	service := TKTBlSpaceService on: space.
+
+	service step: [ space root background: Color random ].
+	service stepDelay:	250 milliSeconds.
+	service start.
+	
+	[  3 seconds wait.
+		service stop.
+		space close ] fork
+
+"  We kind of emulate this:
+	space
+		enqueueTask:
+			(BlRepeatedTaskAction new
+				delay: 250 milliSeconds;
+				action: [ space root background: Color random ];
+				yourself)."
+]

--- a/src/Bloc-Taskit-Tests/TKTBlocTest.class.st
+++ b/src/Bloc-Taskit-Tests/TKTBlocTest.class.st
@@ -1,0 +1,56 @@
+Class {
+	#name : #TKTBlocTest,
+	#superclass : #BlParameterizedHostTest,
+	#category : #'Bloc-Taskit-Tests'
+}
+
+{ #category : #running }
+TKTBlocTest >> isBeingExecutedInTaskPhase [
+
+	^ thisContext stack anySatisfy: [ :each |
+		  each receiver class = BlSpaceFrameTaskPhase ]
+]
+
+{ #category : #tests }
+TKTBlocTest >> testRunner [
+
+	| space runner |
+	space := self newTestingSpace.
+	space root background: Color green.
+
+	runner := TKTBlSpaceRunner on: space.
+	runner schedule: [
+		space root background: Color red.
+		self assert: self isBeingExecutedInTaskPhase ] asTask.
+
+	"Task is not executed immediately"
+	self
+		assert: space root background paint color
+		equals: Color green.
+	"Check again after pulse"
+	self waitTestingSpaces.
+	self
+		assert: space root background paint color
+		equals: Color red
+]
+
+{ #category : #tests }
+TKTBlocTest >> testService [
+
+	| space service count |
+	space := self newTestingSpace.
+	space show.
+
+	service := TKTBlSpaceService on: space.
+	count := 0.
+	service step: [
+		count := count + 1.
+		self assert: self isBeingExecutedInTaskPhase ].
+	service stepDelay: 50 milliSeconds.
+	service start.
+
+	0.5 seconds wait.
+	service stop waitForCompletion: 1 second.
+	
+	self assert: count > 1
+]

--- a/src/Bloc-Taskit-Tests/package.st
+++ b/src/Bloc-Taskit-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Bloc-Taskit-Tests' }

--- a/src/Bloc-Taskit/TKTBlSpaceRunner.class.st
+++ b/src/Bloc-Taskit/TKTBlSpaceRunner.class.st
@@ -1,3 +1,6 @@
+"
+I'm a TaskIt runner associated with a Bloc space.
+"
 Class {
 	#name : #TKTBlSpaceRunner,
 	#superclass : #TKTRunner,

--- a/src/Bloc-Taskit/TKTBlSpaceRunner.class.st
+++ b/src/Bloc-Taskit/TKTBlSpaceRunner.class.st
@@ -1,0 +1,61 @@
+Class {
+	#name : #TKTBlSpaceRunner,
+	#superclass : #TKTRunner,
+	#instVars : [
+		'space'
+	],
+	#category : #'Bloc-Taskit-Objects'
+}
+
+{ #category : #examples }
+TKTBlSpaceRunner class >> example1 [
+
+	| space runner |
+	space := BlSpace new.
+	space
+		extent: 100@100;
+		show.
+
+	runner := TKTBlSpaceRunner on: space.
+
+	[	17 timesRepeat: [
+			runner schedule: [
+				space root background: Color random ] asTask.
+			250 milliSeconds wait ].
+
+		runner stop.
+		space close ] fork
+
+"  We kind of emulate this:
+	space
+		enqueueTask:
+			(BlRepeatedTaskAction new
+				delay: 250 milliSeconds;
+				action: [ space root background: Color random ];
+				yourself)."
+]
+
+{ #category : #'instance creation' }
+TKTBlSpaceRunner class >> on: aBlSpace [
+	
+	^ self basicNew
+		initializeOn: aBlSpace;
+		yourself
+]
+
+{ #category : #initialization }
+TKTBlSpaceRunner >> initializeOn: aBlSpace [ 
+
+	self initialize.
+	
+	space := aBlSpace
+]
+
+{ #category : #schedulling }
+TKTBlSpaceRunner >> scheduleTaskExecution: aTaskExecution [
+
+	space enqueueTask:
+		(BlTaskAction new
+			action: [ self executeTask: aTaskExecution ];
+			yourself)
+]

--- a/src/Bloc-Taskit/TKTBlSpaceRunner.class.st
+++ b/src/Bloc-Taskit/TKTBlSpaceRunner.class.st
@@ -10,34 +10,6 @@ Class {
 	#category : #'Bloc-Taskit-Objects'
 }
 
-{ #category : #examples }
-TKTBlSpaceRunner class >> example1 [
-
-	| space runner |
-	space := BlSpace new.
-	space
-		extent: 100@100;
-		show.
-
-	runner := TKTBlSpaceRunner on: space.
-
-	[	17 timesRepeat: [
-			runner schedule: [
-				space root background: Color random ] asTask.
-			250 milliSeconds wait ].
-
-		runner stop.
-		space close ] fork
-
-"  We kind of emulate this:
-	space
-		enqueueTask:
-			(BlRepeatedTaskAction new
-				delay: 250 milliSeconds;
-				action: [ space root background: Color random ];
-				yourself)."
-]
-
 { #category : #'instance creation' }
 TKTBlSpaceRunner class >> on: aBlSpace [
 	

--- a/src/Bloc-Taskit/TKTBlSpaceService.class.st
+++ b/src/Bloc-Taskit/TKTBlSpaceService.class.st
@@ -1,0 +1,77 @@
+"
+I'm a TaskIt service associated with a Bloc space.
+"
+Class {
+	#name : #TKTBlSpaceService,
+	#superclass : #TKTService,
+	#instVars : [
+		'space',
+		'actionBlock'
+	],
+	#category : #'Bloc-Taskit-Objects'
+}
+
+{ #category : #examples }
+TKTBlSpaceService class >> example1 [
+
+	| space service |
+	space := BlSpace new.
+	space
+		extent: 100@100;
+		show.
+
+	service := TKTBlSpaceService on: space.
+
+	service step: [ space root background: Color random ].
+	service stepDelay:	250 milliSeconds.
+	service start.
+	
+	[  3 seconds wait.
+		service stop.
+		space close ] fork
+
+"  We kind of emulate this:
+	space
+		enqueueTask:
+			(BlRepeatedTaskAction new
+				delay: 250 milliSeconds;
+				action: [ space root background: Color random ];
+				yourself)."
+]
+
+{ #category : #'instance creation' }
+TKTBlSpaceService class >> on: aBlSpace [
+	
+	^ self basicNew
+		initializeOn: aBlSpace;
+		yourself
+]
+
+{ #category : #initialization }
+TKTBlSpaceService >> initializeOn: aBlSpace [ 
+
+	self initialize.
+	
+	space := aBlSpace
+]
+
+{ #category : #accessing }
+TKTBlSpaceService >> name [
+
+	^ '{1}/{2}' format: { space. self identityHash }
+]
+
+{ #category : #accessing }
+TKTBlSpaceService >> step: aBlockClosure [
+
+	actionBlock := aBlockClosure
+]
+
+{ #category : #stepping }
+TKTBlSpaceService >> stepService [
+
+	space enqueueTask:
+		(BlTaskAction new
+			action: actionBlock;
+			yourself)
+]

--- a/src/Bloc-Taskit/TKTBlSpaceService.class.st
+++ b/src/Bloc-Taskit/TKTBlSpaceService.class.st
@@ -11,34 +11,6 @@ Class {
 	#category : #'Bloc-Taskit-Objects'
 }
 
-{ #category : #examples }
-TKTBlSpaceService class >> example1 [
-
-	| space service |
-	space := BlSpace new.
-	space
-		extent: 100@100;
-		show.
-
-	service := TKTBlSpaceService on: space.
-
-	service step: [ space root background: Color random ].
-	service stepDelay:	250 milliSeconds.
-	service start.
-	
-	[  3 seconds wait.
-		service stop.
-		space close ] fork
-
-"  We kind of emulate this:
-	space
-		enqueueTask:
-			(BlRepeatedTaskAction new
-				delay: 250 milliSeconds;
-				action: [ space root background: Color random ];
-				yourself)."
-]
-
 { #category : #'instance creation' }
 TKTBlSpaceService class >> on: aBlSpace [
 	

--- a/src/Bloc-Taskit/package.st
+++ b/src/Bloc-Taskit/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Bloc-Taskit' }


### PR DESCRIPTION
Created with Pablo last week.

Demo script:

```smalltalk 

space := BlSpace new.
space
	useMorphicHost;
	extent: 200@200;
	show.

"action 1"
space enqueueTask:
	(BlTaskAction new
		action: [ space root background: Color random ];
		yourself).

"action 2"
runner := TKTBlSpaceRunner on: space.
runner schedule: [ space root background: Color random ] asTask.


"repeatable 1"
space enqueueTask:
	(BlRepeatedTaskAction new
		delay: 250 milliSeconds;
		action: [ space root background: Color random ];
		yourself).

"repeatable 2"
service := TKTParameterizableService new.
service name: 'Change background'.
service step: [
	space enqueueTask: (BlTaskAction new
		action: [space root background: Color random ];
		yourself) ].
service stepDelay: 250 milliSeconds.
service start.
"service stop."

```