### PR TITLE
Add BlEvent>>consume that is equivalent to consume: true

### DIFF
--- a/src/Bloc-DevTool/BlSelectionTool.class.st
+++ b/src/Bloc-DevTool/BlSelectionTool.class.st
@@ -40,8 +40,8 @@ BlSelectionTool >> dragEvent: anEvent [
 
 { #category : #'dnd handlers' }
 BlSelectionTool >> dragStartEvent: anEvent [
-	anEvent consumed: true.
-	
+
+	anEvent consume.
 	self resetCurrentSelections.
 	startPosition := anEvent position.
 	selectionRect size:50@50; position:startPosition.

--- a/src/Bloc-PullAndSlide/BlScrollSlideHandler.class.st
+++ b/src/Bloc-PullAndSlide/BlScrollSlideHandler.class.st
@@ -22,10 +22,11 @@ BlScrollSlideHandler >> initialize [
 
 { #category : #'mouse handlers' }
 BlScrollSlideHandler >> mouseWheelEvent: anEvent [
+
 	| aTargetElement |
-	anEvent consumed: true.
+	anEvent consume.
 	
-	aTargetElement := targetElement ifNil: anEvent currentTarget.
+	aTargetElement := targetElement ifNil: [ anEvent currentTarget ].
 
 	aTargetElement children accountedByLayout do: [ :aChild |
 		| aHorizontalScrollDelta aVerticalScrollDelta |

--- a/src/Bloc-PullAndSlide/BlSlideHandler.class.st
+++ b/src/Bloc-PullAndSlide/BlSlideHandler.class.st
@@ -11,10 +11,10 @@ Class {
 
 { #category : #'dnd handlers' }
 BlSlideHandler >> dragEvent: anEvent [
+
 	| aStartPosition aCurrentPosition aDelta aTargetElement |
-	anEvent consumed: true.
-	
-	aTargetElement := targetElement ifNil: anEvent currentTarget.
+	anEvent consume.
+	aTargetElement := targetElement ifNil: [ anEvent currentTarget ].
 
 	aStartPosition := aTargetElement globalPointToChildren: dragStartPosition.
 	aCurrentPosition := aTargetElement globalPointToChildren: anEvent position.
@@ -33,13 +33,17 @@ BlSlideHandler >> dragEvent: anEvent [
 
 { #category : #'dnd handlers' }
 BlSlideHandler >> dragStartEvent: anEvent [
-	anEvent consumed: true.
+
+	anEvent consume.
 
 	"drag start position in space"
 	dragStartPosition := anEvent position.
 	
-	(targetElement ifNil: anEvent currentTarget) children accountedByLayout
-		do: [ :aChild | aChild userData at: #slideHandlerStartPosition put: aChild constraints position ]
+	(targetElement ifNil: [ anEvent currentTarget ]) children accountedByLayout
+		do: [ :aChild |
+			aChild userData
+				at: #slideHandlerStartPosition
+				put: aChild constraints position ]
 ]
 
 { #category : #accessing }

--- a/src/Bloc/BlEvent.class.st
+++ b/src/Bloc/BlEvent.class.st
@@ -155,7 +155,14 @@ BlEvent >> capturingTarget: aTBlEventTarget [
 ]
 
 { #category : #testing }
+BlEvent >> consume [
+
+	consumed := true
+]
+
+{ #category : #testing }
 BlEvent >> consumed: aBoolean [
+
 	consumed := aBoolean
 ]
 

--- a/src/Bloc/BlSelectionHandler.class.st
+++ b/src/Bloc/BlSelectionHandler.class.st
@@ -26,7 +26,8 @@ BlSelectionHandler >> computeSelectionArea [
 
 { #category : #'dnd handlers' }
 BlSelectionHandler >> dragEndEvent: anEvent [	
-	anEvent consumed: true.
+
+	anEvent consume.
 		
 	origin := nil.
 	corner := nil.
@@ -41,7 +42,7 @@ BlSelectionHandler >> dragEvent: anEvent [
 	self hasOrigin
 		ifFalse: [ ^ self ].
 	
-	anEvent consumed: true.
+	anEvent consume.
 	
 	corner := anEvent position.	
 	self computeSelectionArea.
@@ -51,8 +52,8 @@ BlSelectionHandler >> dragEvent: anEvent [
 
 { #category : #'dnd handlers' }
 BlSelectionHandler >> dragStartEvent: anEvent [
-	anEvent consumed: true.
 
+	anEvent consume.
 	origin := anEvent position
 ]
 

--- a/src/Bloc/BlShortcutHandlerWithShortcuts.class.st
+++ b/src/Bloc/BlShortcutHandlerWithShortcuts.class.st
@@ -48,7 +48,7 @@ BlShortcutHandlerWithShortcuts >> handleEvent: aShortcutEvent [
 			| aShortcut |
 			aShortcut := theShortcuts first key.
 			"let users explicitely set consumed to false so it bubbles up"
-			aShortcutEvent consumed: true.
+			aShortcutEvent consume.
 			aShortcut performDueTo: aShortcutEvent ]
 ]
 


### PR DESCRIPTION
@plantec WDYT about adding this `aBlEvent consume` to do the same as `aBlElement consumed: true`?
In my image, I had 87 senders of `consumed:` and almost all of them have true as argument