### PR TITLE
Apply application of world renderer canvas scale factor in #physicalSize on BlMorphicHostSpace to Pharo 12

### DIFF
--- a/src/BlocHost-Morphic/BlMorphicHostSpace.class.st
+++ b/src/BlocHost-Morphic/BlMorphicHostSpace.class.st
@@ -123,7 +123,12 @@ BlMorphicHostSpace >> physicalSize [
 	This size may differ from the logical size on high dpi (retina) screens.
 	In most cases physical size is x2 larger than logical size on retina screens."
 
-	^ (spaceHostMorph width @ spaceHostMorph height) asPhysicalSize
+	| canvasScaleFactor |
+
+	canvasScaleFactor := SystemVersion current major >= 12
+		ifTrue: [ (Smalltalk at: #OSWorldRenderer) canvasScaleFactor ]
+		ifFalse: [ 1 ].
+	^ ((spaceHostMorph width @ spaceHostMorph height) * canvasScaleFactor) asPhysicalSize
 ]
 
 { #category : #'window - properties' }

--- a/src/BlocHost-Morphic/BlMorphicSpaceHostMorph.class.st
+++ b/src/BlocHost-Morphic/BlMorphicSpaceHostMorph.class.st
@@ -23,7 +23,12 @@ BlMorphicSpaceHostMorph >> drawOn: aCanvas [
 		ifTrue: [ ^ self ].
 	hostSpace ifNotNil: [ 
 		aCanvas clipBy: self fullBounds during: [ :aClippedCanvas |
-			aClippedCanvas drawImage: spaceForm at: self position ] ]
+			SystemVersion current major >= 12 ifTrue: [
+				| formSet |
+				formSet := (Smalltalk at: #FormSet) extent: self extent depth: spaceForm depth forms: { spaceForm }.
+				aClippedCanvas drawFormSet: formSet at: self position
+			] ifFalse: [
+				aClippedCanvas drawImage: spaceForm at: self position ] ] ]
 ]
 
 { #category : #geometry }


### PR DESCRIPTION
This pull request applies the changes of pull request #465 to the ‘Pharo12’ branch. The two SystemVersion checks could presumably be dropped, but I kept them to not deviate from the implementation in the ‘dev’ branch.