### PR TITLE
SVG: parse String once and keep a sequence of commands to draw each time

### DIFF
--- a/src/Bloc-Alexandrie-SVG/BlCanvasPathCommand.extension.st
+++ b/src/Bloc-Alexandrie-SVG/BlCanvasPathCommand.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #BlCanvasPathCommand }
+
+{ #category : #'*Bloc-Alexandrie-SVG' }
+BlCanvasPathCommand >> aeApplyOn: cairoContext [
+
+	self subclassResponsibility
+]

--- a/src/Bloc-Alexandrie-SVG/BlCloseCommand.extension.st
+++ b/src/Bloc-Alexandrie-SVG/BlCloseCommand.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #BlCloseCommand }
+
+{ #category : #'*Bloc-Alexandrie-SVG' }
+BlCloseCommand >> aeApplyOn: cairoContext [
+
+	cairoContext closePath
+]

--- a/src/Bloc-Alexandrie-SVG/BlCubicBezierCommand.extension.st
+++ b/src/Bloc-Alexandrie-SVG/BlCubicBezierCommand.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #BlCubicBezierCommand }
+
+{ #category : #'*Bloc-Alexandrie-SVG' }
+BlCubicBezierCommand >> aeApplyOn: cairoContext [
+
+	cairoContext
+		curveVia: from
+		via: controlPoint
+		to: to
+]

--- a/src/Bloc-Alexandrie-SVG/BlEllipticalArcCommand.extension.st
+++ b/src/Bloc-Alexandrie-SVG/BlEllipticalArcCommand.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : #BlEllipticalArcCommand }
+
+{ #category : #'*Bloc-Alexandrie-SVG' }
+BlEllipticalArcCommand >> aeApplyOn: cairoContext [
+
+	cairoContext restoreStateAfter: [
+		"Rotate around center"
+		cairoContext
+			translateBy: center;
+			rotateByRadians: phi;
+			translateBy: center negated.
+
+		"Inspired on: https://www.cairographics.org/cookbook/ellipses/"
+		cairoContext
+			translateBy: center - radiiPoint;
+			scaleBy: radiiPoint.
+
+		cairoContext
+			arcCenter: 1.0 @ 1.0
+	 			radius: 1.0
+				startAngle: startAngle degreesToRadians
+				sweep: sweepAngle degreesToRadians ].
+]

--- a/src/Bloc-Alexandrie-SVG/BlLineCommand.extension.st
+++ b/src/Bloc-Alexandrie-SVG/BlLineCommand.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #BlLineCommand }
+
+{ #category : #'*Bloc-Alexandrie-SVG' }
+BlLineCommand >> aeApplyOn: cairoContext [
+
+	cairoContext lineTo: to
+]

--- a/src/Bloc-Alexandrie-SVG/BlMoveCommand.extension.st
+++ b/src/Bloc-Alexandrie-SVG/BlMoveCommand.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #BlMoveCommand }
+
+{ #category : #'*Bloc-Alexandrie-SVG' }
+BlMoveCommand >> aeApplyOn: cairoContext [
+
+	cairoContext moveTo: to
+]

--- a/src/Bloc-Alexandrie-SVG/BlQuadraticBezierCommand.extension.st
+++ b/src/Bloc-Alexandrie-SVG/BlQuadraticBezierCommand.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #BlQuadraticBezierCommand }
+
+{ #category : #'*Bloc-Alexandrie-SVG' }
+BlQuadraticBezierCommand >> aeApplyOn: cairoContext [
+
+	cairoContext
+		quadraticCurveFromCurrentPoint: from
+		via: controlPoint
+		to: to
+]

--- a/src/Bloc-Alexandrie-SVG/BlSvgPath2.extension.st
+++ b/src/Bloc-Alexandrie-SVG/BlSvgPath2.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #BlSvgPath2 }
+
+{ #category : #'*Bloc-Alexandrie-SVG' }
+BlSvgPath2 >> aeApplyTo: aeCanvas element: aBlElement [
+
+	aeCanvas pathFactory: [ :cairoContext |
+		"cairoContext useFillRuleWinding. <-- default for SVG"
+		commands do: [ :each | each aeApplyOn: cairoContext ] ]
+]

--- a/src/Bloc-Alexandrie-SVG/BlSvgPathCanvasCommandHandler.class.st
+++ b/src/Bloc-Alexandrie-SVG/BlSvgPathCanvasCommandHandler.class.st
@@ -1,0 +1,206 @@
+Class {
+	#name : #BlSvgPathCanvasCommandHandler,
+	#superclass : #Object,
+	#instVars : [
+		'lastControlPoint',
+		'currentPosition',
+		'isAbsolute',
+		'commands',
+		'initialPosition'
+	],
+	#category : #'Bloc-Alexandrie-SVG'
+}
+
+{ #category : #API }
+BlSvgPathCanvasCommandHandler >> closePath [
+	
+	self ensureResetLastControlPoint.
+
+	currentPosition := initialPosition.
+	initialPosition := nil.
+
+	commands add: BlCloseCommand new
+]
+
+{ #category : #accessing }
+BlSvgPathCanvasCommandHandler >> commands [
+
+	^ commands
+]
+
+{ #category : #API }
+BlSvgPathCanvasCommandHandler >> cubicBezierVia: p1 and: p2 to: aPoint [
+
+	| pt1 |
+	pt1 := self toAbsolute: p1.
+	lastControlPoint := self toAbsolute: p2.
+	currentPosition := self toAbsolute: aPoint.
+	self ensureRememberInitialPosition.
+
+	commands add:
+		(BlCubicBezierCommand
+			from: pt1
+			controlPoint: lastControlPoint
+			to: currentPosition)
+]
+
+{ #category : #API }
+BlSvgPathCanvasCommandHandler >> ellipticalArcRotation: radiiPoint xAxisRotation: xAxisRotationInDegrees largeArcFlag: isLargeArc sweepFlag: isSweep to: toPosition [
+
+	| startPosition |
+	self ensureResetLastControlPoint.
+
+	startPosition := currentPosition.
+	currentPosition := self toAbsolute: toPosition.
+	self ensureRememberInitialPosition.
+
+	commands add: (BlEllipticalArcCommand
+		from: startPosition
+		rotation: radiiPoint
+		xAxisRotation: xAxisRotationInDegrees
+		largeArcFlag: isLargeArc
+		sweepFlag: isSweep
+		to: currentPosition)
+]
+
+{ #category : #private }
+BlSvgPathCanvasCommandHandler >> ensureRememberInitialPosition [
+
+	initialPosition ifNotNil: [ ^ self ].
+	initialPosition := currentPosition
+]
+
+{ #category : #private }
+BlSvgPathCanvasCommandHandler >> ensureResetLastControlPoint [
+
+	lastControlPoint := nil
+]
+
+{ #category : #API }
+BlSvgPathCanvasCommandHandler >> horizontalLineTo: x [
+
+	self ensureResetLastControlPoint.
+
+	currentPosition :=
+		isAbsolute
+			ifTrue: [ x @ currentPosition y ]
+			ifFalse: [ (x + currentPosition x) @ currentPosition y ].
+	self ensureRememberInitialPosition.
+
+	commands add: (BlLineCommand to: currentPosition)
+]
+
+{ #category : #initialization }
+BlSvgPathCanvasCommandHandler >> initialize [
+
+	super initialize.
+
+	commands := OrderedCollection new.
+
+	currentPosition := 0.0 @ 0.0.
+	initialPosition := nil.
+	lastControlPoint := nil
+
+]
+
+{ #category : #accessing }
+BlSvgPathCanvasCommandHandler >> isAbsolute: aBoolean [
+
+	isAbsolute := aBoolean
+]
+
+{ #category : #API }
+BlSvgPathCanvasCommandHandler >> lineTo: aPoint [
+
+	self ensureResetLastControlPoint.
+
+	currentPosition := self toAbsolute: aPoint.
+	self ensureRememberInitialPosition.
+	
+	commands add: (BlLineCommand to: currentPosition)
+]
+
+{ #category : #API }
+BlSvgPathCanvasCommandHandler >> moveTo: aPoint [
+
+	self ensureResetLastControlPoint.
+
+	currentPosition := self toAbsolute: aPoint.
+	self ensureRememberInitialPosition.
+
+	commands add: (BlMoveCommand to: currentPosition)
+]
+
+{ #category : #API }
+BlSvgPathCanvasCommandHandler >> quadraticBezierVia: p1 to: aPoint [
+
+	| startPoint |
+	startPoint := currentPosition.
+	lastControlPoint := self toAbsolute: p1.
+	currentPosition := self toAbsolute: aPoint.
+	self ensureRememberInitialPosition.
+
+	commands add: (BlQuadraticBezierCommand
+		from: startPoint
+		controlPoint: lastControlPoint
+		to: currentPosition)
+]
+
+{ #category : #API }
+BlSvgPathCanvasCommandHandler >> smoothCubicBezierVia: p2 to: aPoint [
+
+	| startPoint firstControlPoint |
+	startPoint := currentPosition.
+	firstControlPoint :=
+		lastControlPoint
+			ifNil: [ startPoint ]
+			ifNotNil: [ startPoint * 2 - lastControlPoint ].
+	lastControlPoint := self toAbsolute: p2.
+	currentPosition := self toAbsolute: aPoint.
+	self ensureRememberInitialPosition.
+
+	commands add: (BlCubicBezierCommand
+		from: firstControlPoint
+		controlPoint: lastControlPoint
+		to: currentPosition)
+]
+
+{ #category : #API }
+BlSvgPathCanvasCommandHandler >> smoothQuadraticBezierTo: aPoint [
+
+	| startPoint |
+	startPoint := currentPosition.
+	lastControlPoint :=
+		lastControlPoint
+			ifNil: [ startPoint ]
+			ifNotNil: [ startPoint * 2 - lastControlPoint ].
+	currentPosition := self toAbsolute: aPoint.
+	self ensureRememberInitialPosition.
+
+	commands add: (BlQuadraticBezierCommand
+		from: startPoint
+		controlPoint: lastControlPoint
+		to: currentPosition)
+]
+
+{ #category : #private }
+BlSvgPathCanvasCommandHandler >> toAbsolute: aPoint [
+
+	^ isAbsolute
+		  ifTrue: [ aPoint ]
+		  ifFalse: [ currentPosition + aPoint ]
+]
+
+{ #category : #API }
+BlSvgPathCanvasCommandHandler >> verticalLineTo: y [
+
+	self ensureResetLastControlPoint.
+
+	currentPosition :=
+		isAbsolute
+			ifTrue: [ currentPosition x @ y ]
+			ifFalse: [ 0 @ y ].
+	self ensureRememberInitialPosition.
+
+	commands add: (BlLineCommand to: currentPosition)
+]

--- a/src/Bloc-Alexandrie-Tests/BACanvasPathCommandRenderTest.class.st
+++ b/src/Bloc-Alexandrie-Tests/BACanvasPathCommandRenderTest.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : #BACanvasPathCommandRenderTest,
+	#superclass : #AePixelMatchTest,
+	#category : #'Bloc-Alexandrie-Tests-Base'
+}
+
+{ #category : #hooks }
+BACanvasPathCommandRenderTest class >> allFormSelectors [
+
+	^ self selectors select: [ :each | each isUnary and: [each beginsWith: 'render'] ]
+]
+
+{ #category : #hooks }
+BACanvasPathCommandRenderTest >> expectedFormsDirectory [
+
+	| repo |
+	repo := IceRepository registry detect: [ :each | each name asLowercase = 'bloc' ].
+	^ repo location / 'tests' / 'commands'
+]

--- a/src/Bloc-SVG/BlCanvasPathCommand.class.st
+++ b/src/Bloc-SVG/BlCanvasPathCommand.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #BlCanvasPathCommand,
+	#superclass : #Object,
+	#category : #'Bloc-SVG-Geometry'
+}

--- a/src/Bloc-SVG/BlCloseCommand.class.st
+++ b/src/Bloc-SVG/BlCloseCommand.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #BlCloseCommand,
+	#superclass : #BlCanvasPathCommand,
+	#category : #'Bloc-SVG-Geometry'
+}

--- a/src/Bloc-SVG/BlCubicBezierCommand.class.st
+++ b/src/Bloc-SVG/BlCubicBezierCommand.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #BlCubicBezierCommand,
+	#superclass : #BlCanvasPathCommand,
+	#instVars : [
+		'from',
+		'controlPoint',
+		'to'
+	],
+	#category : #'Bloc-SVG-Geometry'
+}
+
+{ #category : #'instance creation' }
+BlCubicBezierCommand class >> from: aPoint controlPoint: aPoint2 to: aPoint3 [
+
+	^ self basicNew
+		initializeFrom: aPoint controlPoint: aPoint2 to: aPoint3;
+		yourself
+]
+
+{ #category : #'instance creation' }
+BlCubicBezierCommand >> initializeFrom: aPoint controlPoint: aPoint2 to: aPoint3 [
+
+	self initialize.
+
+	from := aPoint.
+	controlPoint := aPoint2.
+	to := aPoint3
+]

--- a/src/Bloc-SVG/BlEllipticalArcCommand.class.st
+++ b/src/Bloc-SVG/BlEllipticalArcCommand.class.st
@@ -1,0 +1,94 @@
+Class {
+	#name : #BlEllipticalArcCommand,
+	#superclass : #BlCanvasPathCommand,
+	#instVars : [
+		'center',
+		'phi',
+		'radiiPoint',
+		'startAngle',
+		'sweepAngle'
+	],
+	#category : #'Bloc-SVG-Geometry'
+}
+
+{ #category : #'instance creation' }
+BlEllipticalArcCommand class >> from: fromPoint rotation: radiiPoint xAxisRotation: xAxisRotationInDegrees largeArcFlag: isLargeArc sweepFlag: isSweep to: toPoint [
+
+	| x1 y1 x2 y2 dx2 dy2 rx ry coeff cx1 cy1 ux uy vx vy sign xPrime1 yPrime1 radical startAngle sweepAngle cx cy aCenter uySign phi cosAngle sinAngle |
+
+	rx := radiiPoint x.
+	ry := radiiPoint y.
+	x1 := fromPoint x.
+	y1 := fromPoint y.
+	x2 := toPoint x.
+	y2 := toPoint y.
+	dx2 := (x1 - x2) / 2.0.
+	dy2 := (y1 - y2) / 2.0.
+
+	phi := (xAxisRotationInDegrees \\ 360) degreesToRadians.
+	cosAngle := phi cos.
+	sinAngle := phi sin.
+	xPrime1 := cosAngle * dx2 + (sinAngle * dy2).
+	yPrime1 := cosAngle * dy2 - (sinAngle * dx2).
+
+	"Step 2: Compute (cx1, cy1) "
+	radical :=
+		(rx squared * ry squared
+			- (rx squared * yPrime1 squared)
+			- (ry squared * xPrime1 squared))
+				/ (rx squared * yPrime1 squared + (ry squared * xPrime1 squared)).
+	(radical closeTo: 0.0)
+		ifTrue: [
+			radical := 0.0.
+			coeff := 0.0 ]
+		ifFalse: [
+			coeff := radical abs sqrt ].
+	isSweep = isLargeArc ifTrue: [ coeff := coeff negated ].
+	cx1 := coeff * yPrime1.
+	cy1 := (coeff * xPrime1) negated.
+
+	"Step 3: Compute (cx, cy)"
+	cx := cosAngle * cx1 - (sinAngle * cy1) + ((x1 + x2) / 2.0).
+	cy := sinAngle * cx1 + (cosAngle * cy1) + ((y1 + y2) / 2.0).
+	aCenter := cx @ cy.
+		
+	"Step 4: Compute startAngle and sweepAngle"
+	ux := (xPrime1 - cx1) / rx.
+	uy := (yPrime1 - cy1) / ry.
+	vx := (xPrime1 negated - cx1) / rx.
+	vy := (yPrime1 negated - cy1) / ry.
+	sign := ux * vy - (uy * vx) <= 0.0
+		ifTrue: [ -1 ]
+		ifFalse: [ 1 ].
+	uySign := uy = 0
+		ifTrue: [ 1 ]
+		ifFalse: [ uy sign ].
+	startAngle :=
+		((ux / (ux squared + uy squared) sqrt) arcCos * uySign)
+			radiansToDegrees \\ 360.
+	sweepAngle :=
+		(((ux * vx + (uy * vy))
+			/ ((ux squared + uy squared) * (vx squared + vy squared)) abs sqrt)
+			asFloat arcCos * sign) radiansToDegrees \\ 360.
+	(isLargeArc and: [ sweepAngle abs < 180 ]) ifTrue: [
+		sweepAngle := sweepAngle negative
+			ifTrue: [ 360 + sweepAngle ]
+			ifFalse: [ sweepAngle - 360 ]].
+	isSweep
+		ifTrue: [ sweepAngle < 0 ifTrue: [ sweepAngle := sweepAngle + 360 ]]
+		ifFalse: [ sweepAngle > 0 ifTrue: [ sweepAngle := sweepAngle - 360 ]].
+
+	^ self new
+		initializeCenter: aCenter phi: phi radiiPoint: radiiPoint startAngle: startAngle sweepAngle: sweepAngle;
+		yourself
+]
+
+{ #category : #initialization }
+BlEllipticalArcCommand >> initializeCenter: aCenter phi: aPhi radiiPoint: aRadiiPoint startAngle: aStartAngle sweepAngle: aSweepAngle [
+
+	center := aCenter.
+	phi := aPhi.
+	radiiPoint := aRadiiPoint.
+	startAngle := aStartAngle.
+	sweepAngle := aSweepAngle
+]

--- a/src/Bloc-SVG/BlLineCommand.class.st
+++ b/src/Bloc-SVG/BlLineCommand.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #BlLineCommand,
+	#superclass : #BlCanvasPathCommand,
+	#instVars : [
+		'to'
+	],
+	#category : #'Bloc-SVG-Geometry'
+}
+
+{ #category : #'instance creation' }
+BlLineCommand class >> to: aPoint [ 
+	
+	^ self basicNew
+		initializeTo: aPoint;
+		yourself
+]
+
+{ #category : #initialization }
+BlLineCommand >> initializeTo: aPoint [
+	
+	self initialize.
+	
+	to := aPoint
+]

--- a/src/Bloc-SVG/BlMoveCommand.class.st
+++ b/src/Bloc-SVG/BlMoveCommand.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #BlMoveCommand,
+	#superclass : #BlCanvasPathCommand,
+	#instVars : [
+		'to'
+	],
+	#category : #'Bloc-SVG-Geometry'
+}
+
+{ #category : #'instance creation' }
+BlMoveCommand class >> to: aPoint [ 
+	
+	^ self basicNew
+		initializeTo: aPoint;
+		yourself
+]
+
+{ #category : #initialization }
+BlMoveCommand >> initializeTo: aPoint [
+	
+	self initialize.
+	
+	to := aPoint
+]

--- a/src/Bloc-SVG/BlQuadraticBezierCommand.class.st
+++ b/src/Bloc-SVG/BlQuadraticBezierCommand.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #BlQuadraticBezierCommand,
+	#superclass : #BlCanvasPathCommand,
+	#instVars : [
+		'from',
+		'controlPoint',
+		'to'
+	],
+	#category : #'Bloc-SVG-Geometry'
+}
+
+{ #category : #'instance creation' }
+BlQuadraticBezierCommand class >> from: aPoint controlPoint: aPoint2 to: aPoint3 [ 
+	
+	^ self basicNew
+		initializeFrom: aPoint controlPoint: aPoint2 to: aPoint3;
+		yourself
+]
+
+{ #category : #initialization }
+BlQuadraticBezierCommand >> initializeFrom: aPoint controlPoint: aPoint2 to: aPoint3 [
+
+	self initialize.
+
+	from := aPoint.
+	controlPoint := aPoint2.
+	to := aPoint3
+]

--- a/src/Bloc-SVG/BlSvgPath2.class.st
+++ b/src/Bloc-SVG/BlSvgPath2.class.st
@@ -1,0 +1,75 @@
+"
+I am the `BlElementVectorGeometry` used to represent a SVG path.
+
+A SVG Path is obtained through successives commands, which each symbolizes a movement of the virtual pen drawing the path.
+
+Given a String with a SVG path definition, I collaborate with a parser to generate a sequence of path commands, that will be used to render.
+"
+Class {
+	#name : #BlSvgPath2,
+	#superclass : #BlElementVectorGeometry,
+	#instVars : [
+		'commands',
+		'pathString'
+	],
+	#category : #'Bloc-SVG-Geometry'
+}
+
+{ #category : #'instance creation' }
+BlSvgPath2 class >> pathString: aString [
+	
+	^ self new
+		pathString: aString;
+		yourself
+]
+
+{ #category : #converting }
+BlSvgPath2 >> asElement [
+	"Answer the default element for this geometry. The answer should comply the SVG default style."
+
+	^ super asElement
+		background: Color black;
+		border: BlBorder empty;
+		yourself
+]
+
+{ #category : #'geometry testing' }
+BlSvgPath2 >> containsPoint: aPoint alreadyInGeometryBoundsOf: aBlElement [
+	
+	self flag: #todo. "refine! should have a boolean flag to deknow if it's filled?"
+	
+	^ true
+]
+
+{ #category : #testing }
+BlSvgPath2 >> hasCaps [
+	"The purpose of answering false is optimization. For a simplified implementation, always set caps."
+
+	^ true
+]
+
+{ #category : #testing }
+BlSvgPath2 >> hasJoins [
+	"The purpose of answering false is optimization. For a simplified implementation, always set joins."
+
+	^ true
+]
+
+{ #category : #geometry }
+BlSvgPath2 >> matchExtent: anExtent [
+	"Ignored"
+]
+
+{ #category : #accessing }
+BlSvgPath2 >> pathString: aString [
+
+	| handler |
+	pathString := aString.
+
+	handler := BlSvgPathCanvasCommandHandler new.
+	(BlSvgPathParser
+		on: pathString readStream
+		handler: handler)
+		readUpToEnd.
+	commands := handler commands
+]


### PR DESCRIPTION
Informal test from my Workspace:

```smalltalk
"batman"
pathString := 'M305.378,347.01c48.53,0,87.874,22.104,87.874,49.368c0,27.265-39.344,49.367-87.874,49.367
					c-48.531,0-87.874-22.103-87.874-49.367C217.504,369.114,256.847,347.01,305.378,347.01L305.378,347.01z'.
					
pathString := 'M335.381,362.068c0,0,8.182,11.324,4.426,17.192c-2.754,4.305-7.377,5.384-11.266,5.384
					c-11.438,0-11.85-6.506-11.85-6.506l-1.571-19.8l-5.343,8.486h-8.8l-5.343-8.486l-1.571,19.8c0,0-0.413,6.506-11.851,6.506
					c-3.888,0-8.51-1.08-11.265-5.384c-3.756-5.869,4.426-17.192,4.426-17.192c-22.527,6.229-38.03,19.251-38.03,34.31
					c0,11.756,9.451,22.27,24.313,29.281c-1.76-2.483-6.095-9.704-1.222-14.834c5.972-6.285,15.4-2.513,19.486,3.772
					c0,0,0.314-7.229,7.543-6.285c7.229,0.941,16.657,9.429,17.914,19.484c1.257-10.056,10.686-18.543,17.914-19.484
					c7.229-0.944,7.543,6.285,7.543,6.285c4.086-6.285,13.515-10.058,19.487-3.772c4.872,5.13,0.537,12.351-1.223,14.834
					c14.862-7.012,24.313-17.525,24.313-29.281C373.411,381.32,357.907,368.298,335.381,362.068L335.381,362.068z M305.378,351.931
					c43.694,0,79.116,19.9,79.116,44.447s-35.422,44.448-79.116,44.448c-43.695,0-79.118-19.901-79.118-44.448
					S261.683,351.931,305.378,351.931L305.378,351.931z'.

pathString := '
	M335.381,362.068
	c0,0,8.182,11.324,4.426,17.192
	c-2.754,4.305-7.377,5.384-11.266,5.384
	c-11.438,0-11.85-6.506-11.85-6.506
	l-1.571-19.8
	l-5.343,8.486
	h-8.8
	z'.

"tree"
pathString := 'M1000,200 Q950,400 800,500 Q600,600 750,650 T700,850 Q400,1100 600,1100 T500,1400   Q250,1600 450,1600 L850,1600 Q950,1600 950,1700 h95'.

pathString := '
		M100,20
      Q95,40 80,50
      Q60,60 75,65
      h40'.

pathString := '
		M100,20
      L95,40 80,50
      L60,60 75,65
      h40'.


pathString := '
	M 5,0
	Q 20,35 35,40
	'.

handler := BlSvgPathCanvasCommandHandler new.

(BlSvgPathParser
	on: pathString readStream
	handler: handler)
	readUpToEnd.

aSurface := AeCairoImageSurface
	  extent: 500 asPoint
	  format: AeCairoSurfaceFormat rgb24.
aContext := aSurface newContext.

"aContext useFillRuleWinding. "
"Paint background"
aContext
	sourceColor: Color paleGreen;
	paint.

aContext scaleBy: 5 asPoint.

handler commands do: [ :each | each aeApplyOn: aContext ].

aContext
	sourceColor: Color green;
	fillPreserve;
	sourceColor: Color black;
	stroke.

aSurface.
```