### PR TITLE
Fix some bugs in export to Form

### DIFF
--- a/src/Bloc-Alexandrie-Exporter/BAExporter.class.st
+++ b/src/Bloc-Alexandrie-Exporter/BAExporter.class.st
@@ -67,7 +67,7 @@ BAExporter >> element: aBlElement [
 BAExporter >> export [
 
 	| aCanvas aBounds |
-	element forceLayout.
+	element isLayoutRequested ifTrue: [ element forceLayout ].
 
 	aBounds := element invalidationBoundsInParent.
 

--- a/src/Bloc-Alexandrie-Exporter/BAExporter.class.st
+++ b/src/Bloc-Alexandrie-Exporter/BAExporter.class.st
@@ -65,20 +65,20 @@ BAExporter >> element: aBlElement [
 
 { #category : #'api - exporting' }
 BAExporter >> export [
-	
+
 	| aCanvas aBounds |
 	element forceLayout.
 
-	aBounds := element invalidationBoundsInSpace.
-	
-	aCanvas := self newCanvas: (aBounds extent * scale).
+	aBounds := element invalidationBoundsInParent.
+
+	aCanvas := self newCanvas: aBounds extent * scale.
 
 	aCanvas
 		clear: self background;
 		pathScale: scale asPoint;
 		pathTranslate: aBounds origin negated.
 	element aeFullDrawOn: aCanvas.
-	
+
 	^ self finishExport: aCanvas
 ]
 

--- a/src/Bloc-Alexandrie/BlElement.extension.st
+++ b/src/Bloc-Alexandrie/BlElement.extension.st
@@ -20,9 +20,10 @@ BlElement >> aeAsForm [
 	self isLayoutRequested ifTrue: [ self forceLayout ].
 
 	"We want to consider our border, effect, as well as children's."
-	invalidationBounds := self invalidationBoundsInSpace.
+	invalidationBounds := self invalidationBoundsInParent.
 	aCanvas := AeCanvas extent: invalidationBounds extent.
 	aCanvas pathTranslate: invalidationBounds origin negated.
+
 	self aeFullDrawOn: aCanvas.
 	^ aCanvas asForm
 ]

--- a/src/Bloc/BlElement.class.st
+++ b/src/Bloc/BlElement.class.st
@@ -2173,6 +2173,13 @@ BlElement >> invalidationBounds: aBounds [
 ]
 
 { #category : #accessing }
+BlElement >> invalidationBoundsInParent [
+
+	^ self localBoundsToParent: (BlBounds fromRectangle: self invalidationBounds)
+
+]
+
+{ #category : #accessing }
 BlElement >> invalidationBoundsInSpace [
 
 	^ self localBoundsToGlobal: (BlBounds fromRectangle: self invalidationBounds)


### PR DESCRIPTION

With this PR merged, we mitigate what is reported in #561 which is in fact not specific to proportional layout, but to the race condition on computation of layouts (#560).

A way to mitigate (workaround) the race condition is this:

```smalltalk
a := (BlElement new
   id: #A;
   background: Color red;
   constraintsDo: [:constraints |
      constraints horizontal matchParent.
      constraints vertical matchParent.
      constraints padding: (BlInsets all: 20.0) ];
   layout: BlFrameLayout new;
   addChild: (BlElement new
         id: #B;
         background: Color green;
           effect: (BlSimpleShadowEffect
              color: Color white
              offset: 5 @ 15);
         constraintsDo: [:constraints |
            constraints vertical matchParent.
            constraints horizontal exact: 200.
            constraints frame horizontal alignCenter.
            constraints padding: (BlInsets all: 20.0) ];
         layout: BlFrameLayout new;
         addChild: (BlElement new
               id: #C;
               background: Color blue;
               effect: (BlSimpleShadowEffect
                  color: Color white
                  offset: 5 @ 15);
               constraintsDo: [:constraints |
                 constraints horizontal matchParent.
	              constraints frame vertical alignCenter ];
               yourself);
         yourself);
   yourself).

s := a openInSpace.
s extent: 400 asPoint.

exportMaybePostponedBlock := [ :e |
	e isLayoutRequested
		ifTrue: [
			{Time now. 'postpone export'} traceCr.
			form := e whenLayoutedDoOnce: [
				{Time now. '--> export done'} traceCr.
				e exportAsForm inspect ] ]
		ifFalse: [
			{Time now. 'ready to export'} traceCr.
			form := e exportAsForm inspect.
			{Time now. '--> export done'} traceCr ] ].

b := a childWithId: #B.
c := b childWithId: #C.

exportMaybePostponedBlock value: c.
exportMaybePostponedBlock value: b.
exportMaybePostponedBlock value: a.
```

that opens:

<img width="1346" alt="Screenshot 2024-07-24 at 17 54 40" src="https://github.com/user-attachments/assets/fefab74b-ec57-41d4-a2ce-0758ea176b4f">

