### PR TITLE
Make #processEvent:using: on BlMorphicSpaceHostMorph pass special gesture mouse events to the inherited implementation

### DIFF
--- a/src/BlocHost-Morphic/BlMorphicSpaceHostMorph.class.st
+++ b/src/BlocHost-Morphic/BlMorphicSpaceHostMorph.class.st
@@ -157,8 +157,9 @@ BlMorphicSpaceHostMorph >> pointToSpace: aPoint [
 { #category : #'events-processing' }
 BlMorphicSpaceHostMorph >> processEvent: anEvent using: defaultDispatcher [
 	
-	(self isInSpaceArea: anEvent)
-		ifFalse: [ ^ super processEvent: anEvent using: defaultDispatcher ].
+	((self isInSpaceArea: anEvent)
+		and: [ (anEvent isMouse and: [ anEvent isMouseDown and: [ anEvent isSpecialGesture ] ]) not ])
+			ifFalse: [ ^ super processEvent: anEvent using: defaultDispatcher ].
 
 	anEvent sentTo: eventHandler.
 	


### PR DESCRIPTION
This pull request makes `#processEvent:using:` on BlMorphicSpaceHostMorph pass special gesture mouse events to the inherited implementation, so that halos can be opened on a space host morph:

<p align="center">
<img width="600" src="https://github.com/user-attachments/assets/d8822274-b9d1-48cc-8758-41df8eb831f1">
</p>