### PR TITLE
removed unused dragboard variable from BlSpace

### DIFF
--- a/src/Bloc/BlMouseProcessor.class.st
+++ b/src/Bloc/BlMouseProcessor.class.st
@@ -100,7 +100,6 @@ BlMouseProcessor >> fireAsDragEndEvent: anEvent [
 				startButtons: dragStartMask;
 				target: currentDragTarget;
 				gestureSource: currentDragTarget;
-				dragboard: self space dragboard;
 				yourself)
 ]
 
@@ -125,7 +124,6 @@ BlMouseProcessor >> fireAsDragEvent: anEvent [
 				startButtons: dragStartMask;
 				target: currentDragTarget;
 				gestureSource: currentDragTarget;
-				dragboard: self space dragboard;
 				yourself)
 ]
 
@@ -161,7 +159,6 @@ BlMouseProcessor >> fireAsDropEvent: anEvent [
 				gestureSource: currentDragTarget;
 				gestureTarget: anEvent target;
 				startButtons: dragStartMask;
-				dragboard: self space dragboard;
 				yourself)
 ]
 

--- a/src/Bloc/BlSpace.class.st
+++ b/src/Bloc/BlSpace.class.st
@@ -36,7 +36,6 @@ Class {
 		'focusProcessor',
 		'keyboardProcessor',
 		'focusChain',
-		'dragboard',
 		'nextPulseRequested',
 		'currentCursor',
 		'session',
@@ -801,16 +800,6 @@ BlSpace >> doUpdateLayoutBoundary: anElement context: aBlElementBoundsUpdater [
 
 	"...then we layout in measured during previous step bounds"
 	anElement applyLayoutIn: (anElement position extent: anElement measuredBounds extent) context: aBlElementBoundsUpdater
-]
-
-{ #category : #accessing }
-BlSpace >> dragboard [
-	^ dragboard
-]
-
-{ #category : #accessing }
-BlSpace >> dragboard: anObject [
-	dragboard := anObject
 ]
 
 { #category : #'change - layout' }


### PR DESCRIPTION
I noticed this variable that is passed to every event but is never defined so every event just gets a nil variable for nothing, I simply removed it 

<img width="1281" alt="Capture d’écran 2024-08-07 à 16 24 00" src="https://github.com/user-attachments/assets/68c05f05-d658-492a-bfde-20d7cdb5aab9">
