### PR TITLE
Removed 2 unused variables

### DIFF
--- a/src/Bloc/BlBaseDragEvent.class.st
+++ b/src/Bloc/BlBaseDragEvent.class.st
@@ -4,8 +4,7 @@ Class {
 	#instVars : [
 		'gestureSource',
 		'gestureTarget',
-		'dragboard',
-		'startButtons'
+		'dragboard'
 	],
 	#category : #'Bloc-Events'
 }
@@ -56,29 +55,4 @@ BlBaseDragEvent >> gestureTarget: anObject [
 { #category : #testing }
 BlBaseDragEvent >> isBaseDrag [
 	^ true
-]
-
-{ #category : #testing }
-BlBaseDragEvent >> isMiddleButtonDrag [
-	^ startButtons = self class middleButton
-]
-
-{ #category : #testing }
-BlBaseDragEvent >> isPrimaryButtonDrag [
-	^ startButtons = self class primaryButton
-]
-
-{ #category : #testing }
-BlBaseDragEvent >> isSecondaryButtonDrag [
-	^ startButtons = self class secondaryButton
-]
-
-{ #category : #accessing }
-BlBaseDragEvent >> startButtons [
-	^ startButtons
-]
-
-{ #category : #accessing }
-BlBaseDragEvent >> startButtons: anObject [
-	startButtons := anObject
 ]

--- a/src/Bloc/BlMouseProcessor.class.st
+++ b/src/Bloc/BlMouseProcessor.class.st
@@ -8,7 +8,6 @@ Class {
 		'currentDragTarget',
 		'lastMouseTarget',
 		'dndInProgress',
-		'dragStartMask',
 		'pressedButtons',
 		'dragState',
 		'lastMouseMoveEvent',
@@ -97,7 +96,6 @@ BlMouseProcessor >> fireAsDragEndEvent: anEvent [
 
 	self fireEvent:
 			(anEvent asDragEndEvent
-				startButtons: dragStartMask;
 				target: currentDragTarget;
 				gestureSource: currentDragTarget;
 				dragboard: self space dragboard;
@@ -110,7 +108,6 @@ BlMouseProcessor >> fireAsDragEnterEvent: anEvent targets: aCollection [
 		do: [ :t | 
 			self dispatchEvent:
 					(anEvent asDragEnterEvent
-						startButtons: dragStartMask;
 						target: t;
 						gestureSource: currentDragTarget;
 						canBePropagated: false;
@@ -122,7 +119,6 @@ BlMouseProcessor >> fireAsDragEnterEvent: anEvent targets: aCollection [
 BlMouseProcessor >> fireAsDragEvent: anEvent [
 	self	fireEvent:
 			(anEvent asDragEvent
-				startButtons: dragStartMask;
 				target: currentDragTarget;
 				gestureSource: currentDragTarget;
 				dragboard: self space dragboard;
@@ -135,7 +131,6 @@ BlMouseProcessor >> fireAsDragLeaveEvent: anEvent targets: aCollection [
 		do:	[ :t | 
 			self dispatchEvent:
 					(anEvent asDragLeaveEvent
-						startButtons: dragStartMask;
 						target: t;
 						gestureSource: currentDragTarget;
 						canBePropagated: false;
@@ -147,7 +142,6 @@ BlMouseProcessor >> fireAsDragLeaveEvent: anEvent targets: aCollection [
 BlMouseProcessor >> fireAsDragStartEvent: anEvent [
 	^ self fireEvent:
 			(anEvent asDragStartEvent
-				startButtons: dragStartMask;
 				target: anEvent target;
 				gestureSource: anEvent target;
 				yourself)
@@ -160,7 +154,6 @@ BlMouseProcessor >> fireAsDropEvent: anEvent [
 			(anEvent asDropEvent
 				gestureSource: currentDragTarget;
 				gestureTarget: anEvent target;
-				startButtons: dragStartMask;
 				dragboard: self space dragboard;
 				yourself)
 ]
@@ -311,7 +304,6 @@ BlMouseProcessor >> handleMouseLeft: aSpaceMouseLeaveEvent [
 		anEvent := self isDragging
 			           ifTrue: [
 				           BlDragLeaveEvent new
-					           startButtons: dragStartMask;
 					           gestureSource: currentDragTarget ]
 			           ifFalse: [ BlMouseLeaveEvent new ].
 
@@ -489,7 +481,6 @@ BlMouseProcessor >> processDragEnd: aMouseUpEvent [
 	currentDragTarget := nil.
 	dndInProgress := false.
 	lastOverTarget := nil.
-	dragStartMask := 0
 ]
 
 { #category : #'mouse drag' }
@@ -601,7 +592,6 @@ BlMouseProcessor >> reset [
 	currentDragTarget := nil.
 	lastMouseTarget := nil.
 	dndInProgress := false.
-	dragStartMask := 0.
 	pressedButtons := Set new.
 	dragState := BlMouseDragState new
 ]
@@ -643,7 +633,6 @@ BlMouseProcessor >> tryDragStart: aMouseEvent [
 	aDragTarget := aMouseEvent target.
 	
 	aDragStartEvent := (aMouseEvent asDragStartEvent
-		startButtons: dragStartMask;
 		target: aDragTarget;
 		gestureSource: aDragTarget;
 		yourself).


### PR DESCRIPTION
`BlMouseProcessor>>dragStartMask` and `BlBaseDragEvent>>startButtons` were removed

`dragStartMask` was only set to 0 in two methods, it was never called and only sent as a parameter of `BlBaseDragEvent>>startButtons:` 

When checking for the usage of this method, I noticed it defined a `startButtons` variable but it was only called in testing methods that were not called but moreover were calling deprecated code, I figured all this code could be deleted (at least I think so) 

Regards,
Enzo 