### PR TITLE
Refactoring event Tests

### DIFF
--- a/src/Bloc-Examples/BlClickEventTest.class.st
+++ b/src/Bloc-Examples/BlClickEventTest.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : #TestCase,
 	#traits : 'TBlDevScripterExamples',
 	#classTraits : 'TBlDevScripterExamples classTrait',
-	#category : #'Bloc-Examples-Event'
+	#category : #'Bloc-Examples-Event-Scripter'
 }
 
 { #category : #'running - elements' }

--- a/src/Bloc-Examples/BlElementBoundsByScripterTest.class.st
+++ b/src/Bloc-Examples/BlElementBoundsByScripterTest.class.st
@@ -19,7 +19,7 @@ BlElementBoundsByScripterTest >> expectedElementExtent [
 { #category : #running }
 BlElementBoundsByScripterTest >> newChild [
 
-	^ BlExampleEventsCountingElement new
+	^ BlEventCountingElement new
 		id: #child;
 		background: (Color veryVeryLightGray alpha: 0.4);
 		constraintsDo: [ :c |

--- a/src/Bloc-Examples/BlEventCountingElement.class.st
+++ b/src/Bloc-Examples/BlEventCountingElement.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #BlExampleEventsCountingElement,
+	#name : #BlEventCountingElement,
 	#superclass : #BlElement,
 	#instVars : [
 		'clickCount',
@@ -26,212 +26,212 @@ Class {
 }
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> blurCount [
+BlEventCountingElement >> blurCount [
 	^ blurCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> blurCount: anObject [
+BlEventCountingElement >> blurCount: anObject [
 	blurCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> clickCount [
+BlEventCountingElement >> clickCount [
 	^ clickCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> clickCount: anObject [
+BlEventCountingElement >> clickCount: anObject [
 	clickCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> dragCount [
+BlEventCountingElement >> dragCount [
 	^ dragCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> dragCount: anObject [
+BlEventCountingElement >> dragCount: anObject [
 	dragCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> dragEndCount [
+BlEventCountingElement >> dragEndCount [
 	^ dragEndCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> dragEndCount: anObject [
+BlEventCountingElement >> dragEndCount: anObject [
 	dragEndCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> dragEnterCount [
+BlEventCountingElement >> dragEnterCount [
 	^ dragEnterCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> dragEnterCount: anObject [
+BlEventCountingElement >> dragEnterCount: anObject [
 	dragEnterCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> dragLeaveCount [
+BlEventCountingElement >> dragLeaveCount [
 	^ dragLeaveCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> dragLeaveCount: anObject [
+BlEventCountingElement >> dragLeaveCount: anObject [
 	dragLeaveCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> dragStartCount [
+BlEventCountingElement >> dragStartCount [
 	^ dragStartCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> dragStartCount: anObject [
+BlEventCountingElement >> dragStartCount: anObject [
 	dragStartCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> dropCount [
+BlEventCountingElement >> dropCount [
 	^ dropCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> dropCount: anObject [
+BlEventCountingElement >> dropCount: anObject [
 	dropCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> focusCount [
+BlEventCountingElement >> focusCount [
 	^ focusCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> focusCount: anObject [
+BlEventCountingElement >> focusCount: anObject [
 	focusCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> focusInCount [
+BlEventCountingElement >> focusInCount [
 	^ focusInCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> focusInCount: anObject [
+BlEventCountingElement >> focusInCount: anObject [
 	focusInCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> focusOutCount [
+BlEventCountingElement >> focusOutCount [
 	^ focusOutCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> focusOutCount: anObject [
+BlEventCountingElement >> focusOutCount: anObject [
 	focusOutCount := anObject
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementBlurCount [
+BlEventCountingElement >> incrementBlurCount [
 	blurCount := blurCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementClickCount [
+BlEventCountingElement >> incrementClickCount [
 	clickCount := clickCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementDragCount [
+BlEventCountingElement >> incrementDragCount [
 	dragCount := dragCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementDragEndCount [
+BlEventCountingElement >> incrementDragEndCount [
 	dragEndCount := dragEndCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementDragEnterCount [
+BlEventCountingElement >> incrementDragEnterCount [
 	dragEnterCount := dragEnterCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementDragLeaveCount [
+BlEventCountingElement >> incrementDragLeaveCount [
 	dragEnterCount := dragLeaveCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementDragStartCount [
+BlEventCountingElement >> incrementDragStartCount [
 	dragStartCount := dragStartCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementDropCount [
+BlEventCountingElement >> incrementDropCount [
 	dropCount := dropCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementFocusCount [
+BlEventCountingElement >> incrementFocusCount [
 	focusCount := focusCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementFocusInCount [
+BlEventCountingElement >> incrementFocusInCount [
 	focusInCount := focusInCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementFocusOutCount [
+BlEventCountingElement >> incrementFocusOutCount [
 	focusOutCount := focusOutCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementMouseDownCount [
+BlEventCountingElement >> incrementMouseDownCount [
 	mouseDownCount := mouseDownCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementMouseEnterCount [
+BlEventCountingElement >> incrementMouseEnterCount [
 	mouseEnterCount := mouseEnterCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementMouseLeaveCount [
+BlEventCountingElement >> incrementMouseLeaveCount [
 	mouseLeaveCount := mouseLeaveCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementMouseMoveCount [
+BlEventCountingElement >> incrementMouseMoveCount [
 	mouseMoveCount := mouseMoveCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementMouseOutCount [
+BlEventCountingElement >> incrementMouseOutCount [
 	mouseOutCount := mouseOutCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementMouseOverCount [
+BlEventCountingElement >> incrementMouseOverCount [
 	mouseOverCount := mouseOverCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementMouseUpCount [
+BlEventCountingElement >> incrementMouseUpCount [
 	mouseUpCount := mouseUpCount + 1
 ]
 
 { #category : #increment }
-BlExampleEventsCountingElement >> incrementPositionInSpaceChangedCount [
+BlEventCountingElement >> incrementPositionInSpaceChangedCount [
 	positionInSpaceChangedCount := positionInSpaceChangedCount + 1
 ]
 
 { #category : #initialization }
-BlExampleEventsCountingElement >> initialize [
+BlEventCountingElement >> initialize [
 
 	super initialize.
 
@@ -364,81 +364,81 @@ BlExampleEventsCountingElement >> initialize [
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseDownCount [
+BlEventCountingElement >> mouseDownCount [
 	^ mouseDownCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseDownCount: anObject [
+BlEventCountingElement >> mouseDownCount: anObject [
 	mouseDownCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseEnterCount [
+BlEventCountingElement >> mouseEnterCount [
 	^ mouseEnterCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseEnterCount: anObject [
+BlEventCountingElement >> mouseEnterCount: anObject [
 	mouseEnterCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseLeaveCount [
+BlEventCountingElement >> mouseLeaveCount [
 	^ mouseLeaveCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseLeaveCount: anObject [
+BlEventCountingElement >> mouseLeaveCount: anObject [
 	mouseLeaveCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseMoveCount [
+BlEventCountingElement >> mouseMoveCount [
 	^ mouseMoveCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseMoveCount: anObject [
+BlEventCountingElement >> mouseMoveCount: anObject [
 	mouseMoveCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseOutCount [
+BlEventCountingElement >> mouseOutCount [
 	^ mouseOutCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseOutCount: anObject [
+BlEventCountingElement >> mouseOutCount: anObject [
 	mouseOutCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseOverCount [
+BlEventCountingElement >> mouseOverCount [
 	^ mouseOverCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseOverCount: anObject [
+BlEventCountingElement >> mouseOverCount: anObject [
 	mouseOverCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseUpCount [
+BlEventCountingElement >> mouseUpCount [
 	^ mouseUpCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> mouseUpCount: anObject [
+BlEventCountingElement >> mouseUpCount: anObject [
 	mouseUpCount := anObject
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> positionInSpaceChangedCount [
+BlEventCountingElement >> positionInSpaceChangedCount [
 	^ positionInSpaceChangedCount
 ]
 
 { #category : #accessing }
-BlExampleEventsCountingElement >> positionInSpaceChangedCount: anObject [
+BlEventCountingElement >> positionInSpaceChangedCount: anObject [
 	positionInSpaceChangedCount := anObject
 ]

--- a/src/Bloc-Examples/BlFocusProcessorTest.class.st
+++ b/src/Bloc-Examples/BlFocusProcessorTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #BlFocusProcessorTest,
 	#superclass : #TestCase,
-	#category : #'Bloc-Examples-Event'
+	#category : #'Bloc-Examples-Event-Scripter'
 }
 
 { #category : #running }
@@ -36,7 +36,7 @@ BlFocusProcessorTest >> newElementWithFocusHandler [
 				c padding: (BlInsets top: 5 right: 5) ];
 			yourself.
 
-	^ BlExampleEventsCountingElement new
+	^ BlEventCountingElement new
 		addChild: aLabel;
 		addEventHandler:
 			(BlEventHandler

--- a/src/Bloc-Examples/BlMouseEventTest.class.st
+++ b/src/Bloc-Examples/BlMouseEventTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #BlMouseEventTest,
 	#superclass : #TestCase,
-	#category : #'Bloc-Examples-Event'
+	#category : #'Bloc-Examples-Event-Asserts'
 }
 
 { #category : #running }

--- a/src/Bloc-Examples/BlMouseProcessorClickTest.class.st
+++ b/src/Bloc-Examples/BlMouseProcessorClickTest.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #BlMouseProcessorClickTest,
 	#superclass : #TestCase,
-	#category : #'Bloc-Examples-Event'
+	#category : #'Bloc-Examples-Event-Scripter'
 }
 
 { #category : #running }
 BlMouseProcessorClickTest >> newScripterElement [
 
-	^ BlExampleEventsCountingElement new
+	^ BlEventCountingElement new
 		  size: 100 @ 75;
 		  position: 50 @ 50;
 		  yourself

--- a/src/Bloc-Examples/BlMouseProcessorEnterLeaveTest.class.st
+++ b/src/Bloc-Examples/BlMouseProcessorEnterLeaveTest.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #BlMouseProcessorEnterLeaveTest,
 	#superclass : #TestCase,
-	#category : #'Bloc-Examples-Event'
+	#category : #'Bloc-Examples-Event-Scripter'
 }
 
 { #category : #running }
 BlMouseProcessorEnterLeaveTest >> newScripterElement [
 
-	^ BlExampleEventsCountingElement new
+	^ BlEventCountingElement new
 		  size: 100 @ 75;
 		  position: 50 @ 50;
 		  yourself

--- a/src/Bloc-Examples/BlMouseProcessorTest.class.st
+++ b/src/Bloc-Examples/BlMouseProcessorTest.class.st
@@ -5,8 +5,52 @@ I contain examples-tests of mouse processor
 Class {
 	#name : #BlMouseProcessorTest,
 	#superclass : #TestCase,
-	#category : #'Bloc-Examples-Event'
+	#instVars : [
+		'mouseProcessor'
+	],
+	#category : #'Bloc-Examples-Event-Asserts'
 }
+
+{ #category : #tests }
+BlMouseProcessorTest >> createAndHandleMiddleMouseDown [
+
+	| anEvent |
+	anEvent := self middleMouseDownEvent.
+	mouseProcessor handleMouseDown: anEvent
+]
+
+{ #category : #tests }
+BlMouseProcessorTest >> createAndHandlePrimaryMouseDown [
+
+	| anEvent |
+	anEvent := self primaryMouseDownEvent.
+	mouseProcessor handleMouseDown: anEvent
+]
+
+{ #category : #tests }
+BlMouseProcessorTest >> createAndHandlePrimaryMouseUp [
+
+	| anEvent |
+	anEvent := self primaryMouseUpEvent.
+	mouseProcessor handleMouseUp: anEvent
+]
+
+{ #category : #tests }
+BlMouseProcessorTest >> createAndHandleSecondaryMouseDown [
+
+	| anEvent |
+	anEvent := self secondaryMouseDownEvent.
+	mouseProcessor handleMouseDown: anEvent.
+	
+]
+
+{ #category : #tests }
+BlMouseProcessorTest >> createAndHandleSecondaryMouseUp [
+
+	| anEvent |
+	anEvent := self secondaryMouseUpEvent.
+	mouseProcessor handleMouseUp: anEvent
+]
 
 { #category : #'running - instance creation' }
 BlMouseProcessorTest >> middleMouseDownEvent [
@@ -18,12 +62,6 @@ BlMouseProcessorTest >> middleMouseDownEvent [
 BlMouseProcessorTest >> middleMouseUpEvent [
 
 	^ BlMouseUpEvent middle
-]
-
-{ #category : #'running - instance creation' }
-BlMouseProcessorTest >> newMouseProcessor [
-
-	^ BlMouseProcessor space: BlSpace new
 ]
 
 { #category : #'running - instance creation' }
@@ -50,35 +88,31 @@ BlMouseProcessorTest >> secondaryMouseUpEvent [
 	^ BlMouseUpEvent secondary
 ]
 
+{ #category : #running }
+BlMouseProcessorTest >> setUp [ 
+
+	mouseProcessor := BlMouseProcessor space: BlSpace new.
+]
+
 { #category : #tests }
 BlMouseProcessorTest >> testClick [
 
-	| aMouseProcessor |
-	aMouseProcessor := self newMouseProcessor.
-
-	aMouseProcessor handleMouseDown: self primaryMouseDownEvent.
-	aMouseProcessor handleMouseUp: self primaryMouseUpEvent.
-
-	self assert: aMouseProcessor pressedButtons isEmpty.
-
-	^ aMouseProcessor
+	self createAndHandlePrimaryMouseDown.
+	self createAndHandlePrimaryMouseUp.
+	self assert: mouseProcessor pressedButtons isEmpty.
 ]
 
 { #category : #tests }
 BlMouseProcessorTest >> testMiddleDown [
 
-	| aMouseProcessor anEvent |
-	aMouseProcessor := self newMouseProcessor.
-	anEvent := self middleMouseDownEvent.
-
-	aMouseProcessor handleMouseDown: anEvent.
-
-	self assert: aMouseProcessor pressedButtons size equals: 1.
-	self assert: (aMouseProcessor pressedButtons includes: BlMouseButton middle)
+	self createAndHandleMiddleMouseDown.
+	self assert: mouseProcessor pressedButtons size equals: 1.
+	self assert:
+		(mouseProcessor pressedButtons includes: BlMouseButton middle)
 ]
 
 { #category : #tests }
-BlMouseProcessorTest >> testMouseProcessorInitialState [
+BlMouseProcessorTest >> testMouseProcessorInitializedEmptyAndWithCorrectSpace [
 
 	| aMouseProcessor aSpace |
 	aSpace := BlSpace new.
@@ -86,81 +120,59 @@ BlMouseProcessorTest >> testMouseProcessorInitialState [
 
 	self assert: aMouseProcessor space equals: aSpace.
 	self assert: aMouseProcessor pressedButtons isEmpty.
-
-	^ aMouseProcessor
 ]
 
 { #category : #tests }
-BlMouseProcessorTest >> testPrimaryDown [
+BlMouseProcessorTest >> testPrimaryDownCorrectlyHandled [
 
-	| aMouseProcessor anEvent |
-	aMouseProcessor := self newMouseProcessor.
-	anEvent := self primaryMouseDownEvent.
-
-	aMouseProcessor handleMouseDown: anEvent.
-
-	self assert: aMouseProcessor pressedButtons size equals: 1.
+	self createAndHandlePrimaryMouseDown.
+	
+	self assert: mouseProcessor pressedButtons size equals: 1.
 	self assert:
-		(aMouseProcessor pressedButtons includes: BlMouseButton primary).
-
-	^ aMouseProcessor
+		(mouseProcessor pressedButtons includes: BlMouseButton primary)
 ]
 
 { #category : #tests }
-BlMouseProcessorTest >> testPrimaryDownSecondaryDown [
+BlMouseProcessorTest >> testPrimaryDownSecondaryDownCorrectlyHandled [
 
-	| aMouseProcessor anEvent |
-	aMouseProcessor := self testPrimaryDown.
-	anEvent := self secondaryMouseDownEvent.
-
-	aMouseProcessor handleMouseDown: anEvent.
-
-	self assert: aMouseProcessor pressedButtons size equals: 2.
+	self createAndHandlePrimaryMouseDown.
+	self createAndHandleSecondaryMouseDown.
+	
+	self assert: mouseProcessor pressedButtons size equals: 2.
 	self assert:
-		(aMouseProcessor pressedButtons includes: BlMouseButton primary).
+		(mouseProcessor pressedButtons includes: BlMouseButton primary).
 	self assert:
-		(aMouseProcessor pressedButtons includes: BlMouseButton secondary).
+		(mouseProcessor pressedButtons includes: BlMouseButton secondary).
 
-	^ aMouseProcessor
 ]
 
 { #category : #tests }
-BlMouseProcessorTest >> testPrimaryDownSecondaryDownPrimaryUp [
+BlMouseProcessorTest >> testPrimaryDownSecondaryDownPrimaryUpCorrectlyHandled [
 
-	| aMouseProcessor anEvent |
-	aMouseProcessor := self testPrimaryDownSecondaryDown.
-	anEvent := self primaryMouseUpEvent.
-
-	aMouseProcessor handleMouseUp: anEvent.
-
-	self assert: aMouseProcessor pressedButtons size equals: 1.
+	self createAndHandlePrimaryMouseDown.
+	self createAndHandleSecondaryMouseDown.
+	self createAndHandlePrimaryMouseUp.
+	self assert: mouseProcessor pressedButtons size equals: 1.
 	self assert:
-		(aMouseProcessor pressedButtons includes: BlMouseButton secondary).
-
-	^ aMouseProcessor
+		(mouseProcessor pressedButtons includes: BlMouseButton secondary)
 ]
 
 { #category : #tests }
-BlMouseProcessorTest >> testPrimaryDownSecondaryDownPrimaryUpSecondaryUp [
+BlMouseProcessorTest >> testPrimaryDownSecondaryDownPrimaryUpSecondaryUpCorrectlyHandled [
 
-	| aMouseProcessor anEvent |
-	aMouseProcessor := self testPrimaryDownSecondaryDownPrimaryUp.
-	anEvent := self secondaryMouseUpEvent.
-
-	aMouseProcessor handleMouseUp: anEvent.
-
-	self assert: aMouseProcessor pressedButtons isEmpty
+	self createAndHandlePrimaryMouseDown.
+	self createAndHandleSecondaryMouseDown.
+	self createAndHandlePrimaryMouseUp.
+	self createAndHandleSecondaryMouseUp.
+	
+	self assert: mouseProcessor pressedButtons isEmpty
 ]
 
 { #category : #tests }
 BlMouseProcessorTest >> testSecondaryDown [
 
-	| aMouseProcessor anEvent |
-	aMouseProcessor := self newMouseProcessor.
-	anEvent := self secondaryMouseDownEvent.
-
-	aMouseProcessor handleMouseDown: anEvent.
-
-	self assert: aMouseProcessor pressedButtons size equals: 1.
-	self assert: (aMouseProcessor pressedButtons includes: BlMouseButton secondary)
+	self createAndHandleSecondaryMouseDown.
+	self assert: mouseProcessor pressedButtons size equals: 1.
+	self assert:
+		(mouseProcessor pressedButtons includes: BlMouseButton secondary)
 ]

--- a/src/Bloc-Examples/BlMouseProcessorTest.class.st
+++ b/src/Bloc-Examples/BlMouseProcessorTest.class.st
@@ -91,6 +91,7 @@ BlMouseProcessorTest >> secondaryMouseUpEvent [
 { #category : #running }
 BlMouseProcessorTest >> setUp [ 
 
+	super setUp.
 	mouseProcessor := BlMouseProcessor space: BlSpace new.
 ]
 

--- a/src/Bloc-Examples/BlMouseWheelEventTest.class.st
+++ b/src/Bloc-Examples/BlMouseWheelEventTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #BlMouseWheelEventTest,
 	#superclass : #TestCase,
-	#category : #'Bloc-Examples-Event'
+	#category : #'Bloc-Examples-Event-Asserts'
 }
 
 { #category : #running }

--- a/src/Bloc-Examples/BlSharedEventDistributorTest.class.st
+++ b/src/Bloc-Examples/BlSharedEventDistributorTest.class.st
@@ -12,11 +12,11 @@ Class {
 BlSharedEventDistributorTest >> example [
 	<sampleInstance>
 
-	| aHandler anElements aContainer |
+	| aHandler elements aContainer |
 	aHandler := self testInstallTwoElements.
-	anElements := aHandler elements.
+	elements := aHandler elements.
 	aContainer := self newContainer.
-	aContainer addChildren: anElements.
+	aContainer addChildren: elements.
 	aHandler shareEvents: {
 			BlMouseEnterEvent.
 			BlMouseLeaveEvent.

--- a/src/Bloc-Examples/BlSpaceEventTest.class.st
+++ b/src/Bloc-Examples/BlSpaceEventTest.class.st
@@ -8,7 +8,7 @@ Class {
 	#instVars : [
 		'space'
 	],
-	#category : #'Bloc-Examples-Event'
+	#category : #'Bloc-Examples-Event-Asserts'
 }
 
 { #category : #running }

--- a/src/Bloc/BlBaseDragEvent.class.st
+++ b/src/Bloc/BlBaseDragEvent.class.st
@@ -4,8 +4,7 @@ Class {
 	#instVars : [
 		'gestureSource',
 		'gestureTarget',
-		'dragboard',
-		'startButtons'
+		'dragboard'
 	],
 	#category : #'Bloc-Events'
 }
@@ -56,29 +55,4 @@ BlBaseDragEvent >> gestureTarget: anObject [
 { #category : #testing }
 BlBaseDragEvent >> isBaseDrag [
 	^ true
-]
-
-{ #category : #testing }
-BlBaseDragEvent >> isMiddleButtonDrag [
-	^ startButtons = self class middleButton
-]
-
-{ #category : #testing }
-BlBaseDragEvent >> isPrimaryButtonDrag [
-	^ startButtons = self class primaryButton
-]
-
-{ #category : #testing }
-BlBaseDragEvent >> isSecondaryButtonDrag [
-	^ startButtons = self class secondaryButton
-]
-
-{ #category : #accessing }
-BlBaseDragEvent >> startButtons [
-	^ startButtons
-]
-
-{ #category : #accessing }
-BlBaseDragEvent >> startButtons: anObject [
-	startButtons := anObject
 ]

--- a/src/Bloc/BlMouseProcessor.class.st
+++ b/src/Bloc/BlMouseProcessor.class.st
@@ -97,7 +97,6 @@ BlMouseProcessor >> fireAsDragEndEvent: anEvent [
 
 	self fireEvent:
 			(anEvent asDragEndEvent
-				startButtons: dragStartMask;
 				target: currentDragTarget;
 				gestureSource: currentDragTarget;
 				dragboard: self space dragboard;
@@ -110,7 +109,6 @@ BlMouseProcessor >> fireAsDragEnterEvent: anEvent targets: aCollection [
 		do: [ :t | 
 			self dispatchEvent:
 					(anEvent asDragEnterEvent
-						startButtons: dragStartMask;
 						target: t;
 						gestureSource: currentDragTarget;
 						canBePropagated: false;
@@ -122,7 +120,6 @@ BlMouseProcessor >> fireAsDragEnterEvent: anEvent targets: aCollection [
 BlMouseProcessor >> fireAsDragEvent: anEvent [
 	self	fireEvent:
 			(anEvent asDragEvent
-				startButtons: dragStartMask;
 				target: currentDragTarget;
 				gestureSource: currentDragTarget;
 				dragboard: self space dragboard;
@@ -135,7 +132,6 @@ BlMouseProcessor >> fireAsDragLeaveEvent: anEvent targets: aCollection [
 		do:	[ :t | 
 			self dispatchEvent:
 					(anEvent asDragLeaveEvent
-						startButtons: dragStartMask;
 						target: t;
 						gestureSource: currentDragTarget;
 						canBePropagated: false;
@@ -147,7 +143,6 @@ BlMouseProcessor >> fireAsDragLeaveEvent: anEvent targets: aCollection [
 BlMouseProcessor >> fireAsDragStartEvent: anEvent [
 	^ self fireEvent:
 			(anEvent asDragStartEvent
-				startButtons: dragStartMask;
 				target: anEvent target;
 				gestureSource: anEvent target;
 				yourself)
@@ -160,7 +155,6 @@ BlMouseProcessor >> fireAsDropEvent: anEvent [
 			(anEvent asDropEvent
 				gestureSource: currentDragTarget;
 				gestureTarget: anEvent target;
-				startButtons: dragStartMask;
 				dragboard: self space dragboard;
 				yourself)
 ]
@@ -311,7 +305,6 @@ BlMouseProcessor >> handleMouseLeft: aSpaceMouseLeaveEvent [
 		anEvent := self isDragging
 			           ifTrue: [
 				           BlDragLeaveEvent new
-					           startButtons: dragStartMask;
 					           gestureSource: currentDragTarget ]
 			           ifFalse: [ BlMouseLeaveEvent new ].
 
@@ -643,7 +636,6 @@ BlMouseProcessor >> tryDragStart: aMouseEvent [
 	aDragTarget := aMouseEvent target.
 	
 	aDragStartEvent := (aMouseEvent asDragStartEvent
-		startButtons: dragStartMask;
 		target: aDragTarget;
 		gestureSource: aDragTarget;
 		yourself).


### PR DESCRIPTION
Hello, 

I refactored some tests on `BlMouseProcessor`

I separated in different tags the Event tests that were written with `assert:` and other written using a Scripted so we can work better if needing to change or delete the `BlDevScripter` class

Regards,
Enzo