### PR TITLE
Add BlDemoScript to allow class methods with a pragma ‘<demo>’ to be executed in a browser

### DIFF
--- a/src/Bloc-DevTool/BlDemoScript.class.st
+++ b/src/Bloc-DevTool/BlDemoScript.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #BlDemoScript,
+	#superclass : #ClyClassScript,
+	#category : #'Bloc-DevTool-Calypso'
+}
+
+{ #category : #'script detection' }
+BlDemoScript class >> isImplementedByMethod: method [
+
+	^ method hasPragmaNamed: #demo
+]
+
+{ #category : #accessing }
+BlDemoScript >> description [
+
+	^ 'Open the demo'
+]
+
+{ #category : #execution }
+BlDemoScript >> executeOn: class [
+
+ 	(super executeOn: class)
+		openInSpace
+]
+
+{ #category : #accessing }
+BlDemoScript >> iconName [
+
+	^ #smallDoIt
+]


### PR DESCRIPTION
This pull request adds BlDemoScript, a subclass of ClyClassScript, to allow class methods with a pragma ‘<demo>’ to be executed in a browser.