### PR TITLE
Remove BlMousePickOutsideEvent>>sendTo:

### DIFF
--- a/src/Bloc/BlMouseDownEvent.class.st
+++ b/src/Bloc/BlMouseDownEvent.class.st
@@ -39,7 +39,10 @@ BlMouseDownEvent class >> secondary [
 { #category : #converting }
 BlMouseDownEvent >> asMouseOutsideEvent [
 
-	^ BlMouseDownOutsideEvent new originalEvent: self; canBePropagated: false; yourself
+	^ BlMouseDownOutsideEvent new
+		  originalEvent: self;
+		  canBePropagated: false;
+		  yourself
 ]
 
 { #category : #testing }

--- a/src/Bloc/BlMousePickOutsideEvent.class.st
+++ b/src/Bloc/BlMousePickOutsideEvent.class.st
@@ -56,9 +56,3 @@ BlMousePickOutsideEvent >> originalEvent: aBlEvent [
 	aBlEvent consume.
 	originalEvent := aBlEvent
 ]
-
-{ #category : #sending }
-BlMousePickOutsideEvent >> sendTo: anObject [
-
-	anObject mousePickOutsideEvent: self
-]

--- a/src/Bloc/BlMouseUpEvent.class.st
+++ b/src/Bloc/BlMouseUpEvent.class.st
@@ -46,7 +46,10 @@ BlMouseUpEvent >> asDoubleClickEvent [
 { #category : #converting }
 BlMouseUpEvent >> asMouseOutsideEvent [
 
-	^ BlMouseUpOutsideEvent new originalEvent: self; canBePropagated: false; yourself
+	^ BlMouseUpOutsideEvent new
+		  originalEvent: self;
+		  canBePropagated: false;
+		  yourself
 ]
 
 { #category : #testing }


### PR DESCRIPTION
It sends an unimplemented selector and both subclasses override it.

Fixes #590