### PR TITLE
Remove unsent BlBasicEventHandler>>#hasOwner

### DIFF
--- a/src/Bloc/BlBasicEventHandler.class.st
+++ b/src/Bloc/BlBasicEventHandler.class.st
@@ -28,14 +28,6 @@ BlBasicEventHandler >> eventsToHandle [
 BlBasicEventHandler >> handleEvent: anEvent [
 ]
 
-{ #category : #testing }
-BlBasicEventHandler >> hasOwner [
-	"Utility #*owner message makes it possible to have a polymorphic way to visualise a tree structure of the elements"
-	<return: #Boolean>
-
-	^ false
-]
-
 { #category : #'api - hooks' }
 BlBasicEventHandler >> onInstalledIn: anObject [
 ]


### PR DESCRIPTION
It is evidently a hook, but it is not overriden.
In fact it is sent, but only by SpPresenter (spec).

Fixes #628