### PR TITLE
removed BlLayout, BlFlowLayout and BlLinearLayout #= and #hash

### DIFF
--- a/src/Bloc-Layout-Tests/BlLayoutTest.class.st
+++ b/src/Bloc-Layout-Tests/BlLayoutTest.class.st
@@ -10,24 +10,24 @@ Class {
 { #category : #tests }
 BlLayoutTest >> testEqualityBlBasicLayout [
 
-	self assert: BlBasicLayout new equals: BlBasicLayout new
+	self deny: BlBasicLayout new equals: BlBasicLayout new
 ]
 
 { #category : #tests }
 BlLayoutTest >> testEqualityBlFlowLayout [
 
-	self assert: BlFlowLayout horizontal equals: BlFlowLayout horizontal.
-	self assert: BlFlowLayout vertical equals: BlFlowLayout vertical.
+	self deny: BlFlowLayout horizontal equals: BlFlowLayout horizontal.
+	self deny: BlFlowLayout vertical equals: BlFlowLayout vertical.
 	self deny: BlFlowLayout horizontal equals: BlFlowLayout vertical.
 
 	self
-		assert: BlFlowLayout horizontal alignTopCenter
+		deny: BlFlowLayout horizontal alignTopCenter
 		equals: BlFlowLayout horizontal alignTopCenter.
 	self
-		assert: BlFlowLayout horizontal alignCenter
+		deny: BlFlowLayout horizontal alignCenter
 		equals: BlFlowLayout horizontal alignCenter.
 	self
-		assert: BlFlowLayout horizontal alignBottomRight
+		deny: BlFlowLayout horizontal alignBottomRight
 		equals: BlFlowLayout horizontal alignBottomRight.
 
 	self
@@ -41,40 +41,26 @@ BlLayoutTest >> testEqualityBlFlowLayout [
 { #category : #tests }
 BlLayoutTest >> testEqualityBlFrameLayout [
 
-	self assert: BlFrameLayout new equals: BlFrameLayout new
+	self deny: BlFrameLayout new equals: BlFrameLayout new
 ]
 
 { #category : #tests }
 BlLayoutTest >> testEqualityBlLinearLayout [
 
 	self
-		assert: BlLinearLayout horizontal
+		deny: BlLinearLayout horizontal
 		equals: BlLinearLayout horizontal.
-	self assert: BlLinearLayout vertical equals: BlLinearLayout vertical.
+	self deny: BlLinearLayout vertical equals: BlLinearLayout vertical.
 	self deny: BlLinearLayout horizontal equals: BlLinearLayout vertical.
 	
-		self
-		assert: (BlLinearLayout horizontal cellSpacing: 5.0)
-		equals: (BlLinearLayout horizontal cellSpacing: 5.0).
 	self
-		deny: (BlLinearLayout horizontal cellSpacing: 4.0)
-		equals: (BlLinearLayout horizontal cellSpacing: 5.0).
-
-	self
-		assert: (BlLinearLayout horizontal interspace: 5.0)
-		equals: (BlLinearLayout horizontal interspace: 5.0).
-	self
-		deny: (BlLinearLayout horizontal interspace: 4.0)
-		equals: (BlLinearLayout horizontal interspace: 5.0).
-
-	self
-		assert: BlLinearLayout horizontal alignTopCenter
+		deny: BlLinearLayout horizontal alignTopCenter
 		equals: BlLinearLayout horizontal alignTopCenter.
 	self
-		assert: BlLinearLayout horizontal alignCenter
+		deny: BlLinearLayout horizontal alignCenter
 		equals: BlLinearLayout horizontal alignCenter.
 	self
-		assert: BlLinearLayout horizontal alignBottomRight
+		deny: BlLinearLayout horizontal alignBottomRight
 		equals: BlLinearLayout horizontal alignBottomRight.
 
 	self
@@ -88,5 +74,5 @@ BlLayoutTest >> testEqualityBlLinearLayout [
 { #category : #tests }
 BlLayoutTest >> testEqualityBlProportionalLayout [
 
-	self assert: BlProportionalLayout new equals: BlProportionalLayout new
+	self deny: BlProportionalLayout new equals: BlProportionalLayout new
 ]

--- a/src/Bloc-Layout/BlFlowLayout.class.st
+++ b/src/Bloc-Layout/BlFlowLayout.class.st
@@ -31,17 +31,6 @@ BlFlowLayout class >> vertical [
 		yourself
 ]
 
-{ #category : #comparing }
-BlFlowLayout >> = anObject [
-
-	self == anObject ifTrue: [ ^ true ].
-	self class = anObject class ifFalse: [ ^ false ].
-	self orientation = anObject orientation ifFalse: [ ^ false ].
-	self horizontalAlignment = anObject horizontalAlignment ifFalse: [ ^ false ].
-	self verticalAlignment = anObject verticalAlignment ifFalse: [ ^ false ].
-	^ true
-]
-
 { #category : #accessing }
 BlFlowLayout >> alignment [
 	^ self horizontalAlignment + self verticalAlignment
@@ -68,14 +57,6 @@ BlFlowLayout >> defaultVerticalAlignment [
 	<return: #BlNullAlignment>
 	
 	^ BlElementAlignment start vertical
-]
-
-{ #category : #comparing }
-BlFlowLayout >> hash [
-
-	^ ((self class hash bitXor: self orientation hash) bitXor:
-		   self horizontalAlignment hash) bitXor:
-		  self verticalAlignment hash
 ]
 
 { #category : #accessing }

--- a/src/Bloc-Layout/BlLinearLayout.class.st
+++ b/src/Bloc-Layout/BlLinearLayout.class.st
@@ -31,23 +31,6 @@ BlLinearLayout class >> vertical [
 	^ self new beVertical
 ]
 
-{ #category : #comparing }
-BlLinearLayout >> = anObject [
-
-	self == anObject ifTrue: [ ^ true ].
-	self class = anObject class ifFalse: [ ^ false ].
-	
-	self cellSpacing = anObject cellSpacing ifFalse: [ ^ false ].
-	self interspace = anObject interspace ifFalse: [ ^ false ].
-	
-	self orientation = anObject orientation ifFalse: [ ^ false ].
-	self horizontalAlignment = anObject horizontalAlignment ifFalse: [
-		^ false ].
-	self verticalAlignment = anObject verticalAlignment ifFalse: [
-		^ false ].
-	^ true
-]
-
 { #category : #'api - alignment' }
 BlLinearLayout >> align: aChildElement horizontal: aBlAlignment [
 	aChildElement constraintsDo: [ :c | (c at: self class) horizontal alignment: aBlAlignment ]

--- a/src/Bloc/BlLayout.class.st
+++ b/src/Bloc/BlLayout.class.st
@@ -91,13 +91,6 @@ BlLayout class >> constraints [
 	^ self subclassResponsibility
 ]
 
-{ #category : #comparing }
-BlLayout >> = anObject [
-
-	self == anObject ifTrue: [ ^ true ].
-	^ self class = anObject class
-]
-
 { #category : #'private - alignment' }
 BlLayout >> align: anElement bounds: elementBounds in: theParentBounds with: aBlElementAlignment [
 	"I don't additionally take element margin or parent padding"


### PR DESCRIPTION
I've passed two days digging and digging everywhere because of an issue related to this bad kind of redefinition of #=. It does'nt make sense to have such #= implementation for so complex objects and that may have specific subclasses. moreover, when one send #layout: with a new layout as argument, it should ensure that the new layout instance is taken,  otherwise, one would have to test the equality then change the current layout state which could lead to  questionable code and many alternatives to check.