### PR TITLE
Remove last remains of event recorders

### DIFF
--- a/src/Bloc/BlSpace.class.st
+++ b/src/Bloc/BlSpace.class.st
@@ -30,7 +30,6 @@ Class {
 		'borderless',
 		'eventDispatcher',
 		'eventListener',
-		'eventRecorder',
 		'mouseProcessor',
 		'focusProcessor',
 		'keyboardProcessor',


### PR DESCRIPTION
Fixes #148

An old issue! accessors do not exist anymore, nor hierarchy of recorders, but still an instvar was present on space.