### PR TITLE
Avoid creation of SDL_Surface, as we only need a ByteArray.

### DIFF
--- a/src/Bloc/BlHostRendererBufferSurface.class.st
+++ b/src/Bloc/BlHostRendererBufferSurface.class.st
@@ -9,8 +9,7 @@ Class {
 	#instVars : [
 		'stride',
 		'buffer',
-		'extent',
-		'strongReference'
+		'extent'
 	],
 	#category : #'Bloc-Universe - Renderer'
 }
@@ -74,10 +73,4 @@ BlHostRendererBufferSurface >> stride [
 BlHostRendererBufferSurface >> stride: aNumber [
 
 	stride := aNumber
-]
-
-{ #category : #accessing }
-BlHostRendererBufferSurface >> strongReference: anObject [
-
-	strongReference := anObject
 ]

--- a/src/BlocHost-OSWindow-SDL2/BlOSWindowSDL2BufferSurfaceRenderer.class.st
+++ b/src/BlocHost-OSWindow-SDL2/BlOSWindowSDL2BufferSurfaceRenderer.class.st
@@ -15,25 +15,23 @@ Class {
 { #category : #initialization }
 BlOSWindowSDL2BufferSurfaceRenderer >> initializeForSurface: aBlHostRendererBufferSurface [
 
-	| textureExtent sdlSurface |
+	| textureExtent stride buffer |
 	textureExtent := aBlHostRendererBufferSurface physicalSize asPoint.
 	
-	sdlSurface := SDL2
-		createRGBSurfaceForCairoWidth: textureExtent x
-		height: textureExtent y.
-
 	sdlRenderer := window backendWindow renderer sdlRenderer.
 
 	texture := sdlRenderer
 		createTextureFormat: SDL_PIXELFORMAT_XRGB8888
-		access: SDL_TEXTUREACCESS_STREAMING
+		access: SDL_TEXTUREACCESS_STATIC
 		width: textureExtent x
 		height: textureExtent y.
 
+	stride := textureExtent x * 4.
+	buffer := ByteArray new: stride * textureExtent y.
+
 	aBlHostRendererBufferSurface
-		strongReference: sdlSurface;
-		buffer: sdlSurface pixels;
-		stride: sdlSurface pitch;
+		buffer: buffer;
+		stride: stride;
 		extent: textureExtent
 ]
 


### PR DESCRIPTION
This should fix #688, as it avoids accessing the pixels of the SDL_Surface.

This is offtopic: changing SDL_TEXTUREACCESS_STREAMING by SDL_TEXTUREACCESS_STATIC... but in my bechmarks, STATIC is slightly faster.