### PR TITLE
Fix issue 786 - Alt key is not recognized on windows, using Morphic backend.

### DIFF
--- a/src/BlocHost-Morphic/BlMorphicEventHandler.class.st
+++ b/src/BlocHost-Morphic/BlMorphicEventHandler.class.st
@@ -63,13 +63,6 @@ BlMorphicEventHandler >> convertKeyModifiersFromEvent: aMorphicEvent [
 	alt := aMorphicEvent altKeyPressed.
 	cmd := aMorphicEvent commandKeyPressed.
 	
-	"on windows, alt is registered as CMD while CMD itself does not exist.
-	https://github.com/feenkcom/gtoolkit/issues/557"
-	OSPlatform current isWindows
-		ifTrue: [
-			alt := cmd.
-			cmd := false ].
-	
 	^ BlKeyModifiers shift: shift ctrl: ctrl alt: alt cmd: cmd
 ]
 


### PR DESCRIPTION
Morphic code must have changed since this issue has been raised in GToolkit (back to 2019). Commenting or removing this code fix the problem.

#786