### PR TITLE
Morphic hosts need to implement delete

### DIFF
--- a/src/BlocHost-Morphic/BlMorphicSteppingHost.class.st
+++ b/src/BlocHost-Morphic/BlMorphicSteppingHost.class.st
@@ -8,6 +8,14 @@ Class {
 }
 
 { #category : #'api - lifecycle' }
+BlMorphicSteppingHost class >> delete [
+	"Required to be polymorphic with Morph.
+	See: https://github.com/pharo-graphics/Bloc/issues/785"
+
+	^ self stop
+]
+
+{ #category : #'api - lifecycle' }
 BlMorphicSteppingHost class >> isRunning [
 
 	^ self currentWorld isStepping: self


### PR DESCRIPTION
Morphic hosts register as stepping morphs then they must implement `#delete`.

Fixes #785. Thanks @LabordePierre for the report and fix.