### PR TITLE
Fix initial BlSpace cursor

### DIFF
--- a/src/Bloc/BlSpace.class.st
+++ b/src/Bloc/BlSpace.class.st
@@ -1145,7 +1145,7 @@ BlSpace >> initialize [
 	self title: self defaultTitle.
 	self focused: false.
 
-	self updateCursor: Cursor normal.
+	self currentCursor: Cursor normal.
 
 	self root space: self
 ]


### PR DESCRIPTION
BlSpace: It wasn't useful to send #updateCursor: as the host space is always nil during initialization.

The bug was visible with a simple `BlSpace new show` in a workspace, and the initial cursor was the text edit cursor. With this change, this doesn't happen anymore.