### PR TITLE
Add #asElement on FormSet

### DIFF
--- a/src/Bloc/FormSet.extension.st
+++ b/src/Bloc/FormSet.extension.st
@@ -5,3 +5,12 @@ FormSet >> asBlBackground [
 
 	^ BlBackground formSet: self
 ]
+
+{ #category : #'*Bloc' }
+FormSet >> asElement [
+
+	^ BlElement new
+		extent: self extent;
+		background: self;
+		yourself
+]


### PR DESCRIPTION
This pull request adds #asElement on FormSet, which uses the support for using a FormSet as background added in pull request #820.