### PR TITLE
Take into account the value of space's fullscreen attribute on open

### DIFF
--- a/src/BlocHost-OSWindow-SDL2/BlOSWindowSDL2Host.class.st
+++ b/src/BlocHost-OSWindow-SDL2/BlOSWindowSDL2Host.class.st
@@ -86,6 +86,7 @@ BlOSWindowSDL2Host >> newAttributesFor: aSpace [
 		extent: aSpace extent;
 		resizable: aSpace isResizable;
 		borderless: aSpace isBorderless;
+		fullscreen: aSpace isFullscreen;
 		visible: false; "There is a race before opening a window and setting the event handler."
 		yourself.
 


### PR DESCRIPTION
Fixes #511 

Test pre-show `fullscreen:` with:

```smalltalk
space := BlSpace new.
space fullscreen: true.
space show.
4 second wait.
space close.
```

Test post-show `fullscreen:` with:

```smalltalk
space := BlSpace new.
space root addChild: (BlTextElement new
	text: ('TOGGLE' asRopedText fontSize: 40; yourself);
	padding: (BlInsets all: 20);
	background: Color cyan;
	addEventFilterOn: BlClickEvent
		do: [ :evt | space fullscreen: space isFullscreen not ];
	yourself).
space fullscreen: true.
space show.
```