### PR TITLE
Add new settings to add developper's tools in a BlSpace.

### DIFF
--- a/src/Bloc-DevTool/BlocSpaceShortcutInspectorTool.class.st
+++ b/src/Bloc-DevTool/BlocSpaceShortcutInspectorTool.class.st
@@ -1,0 +1,44 @@
+"
+I am a tool to open an inspector from a BlSpace.
+"
+Class {
+	#name : #BlocSpaceShortcutInspectorTool,
+	#superclass : #BlocSpaceShortcutTool,
+	#category : #'Bloc-DevTool-Space-tools'
+}
+
+{ #category : #configuration }
+BlocSpaceShortcutInspectorTool class >> defaultIndex [
+
+	^ 1
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutInspectorTool class >> groupName [
+
+	^ 'bloc-space-inspect'
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutInspectorTool class >> settingDescription [
+
+	^ 'Shortcut settings to open an inspector of a BlSpace.'
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutInspectorTool class >> settingLabel [
+
+	^ 'space inspect'
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutInspectorTool class >> shortcutActionOn: aBlSpace [
+
+	aBlSpace inspect
+]
+
+{ #category : #'see class side' }
+BlocSpaceShortcutInspectorTool >> seeClassSide [
+
+	
+]

--- a/src/Bloc-DevTool/BlocSpaceShortcutStatisticsTool.class.st
+++ b/src/Bloc-DevTool/BlocSpaceShortcutStatisticsTool.class.st
@@ -1,0 +1,44 @@
+"
+I am a tool to open a statistics window from a BlSpace.
+"
+Class {
+	#name : #BlocSpaceShortcutStatisticsTool,
+	#superclass : #BlocSpaceShortcutTool,
+	#category : #'Bloc-DevTool-Space-tools'
+}
+
+{ #category : #configuration }
+BlocSpaceShortcutStatisticsTool class >> defaultIndex [
+
+	^ 2
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutStatisticsTool class >> groupName [
+
+	^ 'bloc-space-statistics'
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutStatisticsTool class >> settingDescription [
+
+	^ 'Shortcut settings to open a window that display different statistics.'
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutStatisticsTool class >> settingLabel [
+
+	^ 'statistics window'
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutStatisticsTool class >> shortcutActionOn: aBlSpace [
+
+	aBlSpace showStatisticsWindow
+]
+
+{ #category : #'see class side' }
+BlocSpaceShortcutStatisticsTool >> seeClassSide [
+
+	
+]

--- a/src/Bloc-DevTool/BlocSpaceShortcutTool.class.st
+++ b/src/Bloc-DevTool/BlocSpaceShortcutTool.class.st
@@ -1,0 +1,180 @@
+"
+I am a tool to add and manage different shortcuts to a BlSpace.
+Each shortcut is link to a tool.
+
+To add a new tool you can subclass me and implement the following methods:
+ - #defaultIndex : return a number between 1 and 12. It corresponds to the fonction key that will be used as shortcut.
+ - #groupName : return a symbol that correspond to the settings group (each tool must have a unique symbol).
+ - #settingDescription : return a String that correspond to the description present in the settings.
+ - #settingLabel : return a String that correspond to the name of the tool in the settings.
+ - #shortcutActionOn: : use the BlSpace (the argument of the method) to add the desire effect.
+"
+Class {
+	#name : #BlocSpaceShortcutTool,
+	#superclass : #Object,
+	#classInstVars : [
+		'shortcut',
+		'enabled',
+		'shortcutDomainValues'
+	],
+	#category : #'Bloc-DevTool-Space-tools'
+}
+
+{ #category : #'adding shortcuts' }
+BlocSpaceShortcutTool class >> addShortcutOn: aBlSpace [
+
+	self shortcut ifNil: [ self resetShortcut ].
+
+	aBlSpace userData
+		at: #devTools
+		ifPresent: [ :col | col add: self ]
+		ifAbsentPut: [ OrderedCollection with: self ].
+
+	aBlSpace
+		addEventHandlerOn: BlKeyDownEvent
+		do: [ :evt | self executeShortcutActionOn: aBlSpace withEvent: evt ]
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutTool class >> defaultIndex [
+
+	^ self explicitRequirement
+]
+
+{ #category : #accessing }
+BlocSpaceShortcutTool class >> enabled [
+
+	^ enabled
+]
+
+{ #category : #accessing }
+BlocSpaceShortcutTool class >> enabled: anObject [
+
+	enabled := anObject
+]
+
+{ #category : #'adding shortcuts' }
+BlocSpaceShortcutTool class >> executeShortcutActionOn: aBlSpace withEvent: anEvent [
+
+	self enabled ifFalse: [ ^ self ].
+	anEvent key = self shortcut ifFalse: [ ^ self ].
+	self shortcutActionOn: aBlSpace
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutTool class >> groupName [
+
+	^ self explicitRequirement
+]
+
+{ #category : #reset }
+BlocSpaceShortcutTool class >> resetAllShortcuts [
+
+	<script>
+	BlocSpaceShortcutTool subclassesDo: [ :each | each resetShortcut ]
+]
+
+{ #category : #reset }
+BlocSpaceShortcutTool class >> resetShortcut [
+
+	self shortcut:
+		(BlocSpaceShortcutTool shortcutDomainValues at: self defaultIndex)
+			value
+]
+
+{ #category : #settings }
+BlocSpaceShortcutTool class >> rootGroupSymbol [
+
+	^ #BlocSpaceTools
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutTool class >> settingDescription [
+
+	^ self explicitRequirement
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutTool class >> settingLabel [
+
+	^ self explicitRequirement
+]
+
+{ #category : #settings }
+BlocSpaceShortcutTool class >> settingOn: aBuilder [
+
+	(aBuilder group: self groupName)
+		parent: self rootGroupSymbol;
+		label: self settingLabel capitalized;
+		description: self settingDescription.
+	(aBuilder setting: #enabled)
+		parent: self groupName;
+		label: 'Enables ' , self settingLabel uncapitalized;
+		default: true;
+		target: self;
+		description: 'Enables the shortcut'.
+	(aBuilder pickOne: #shortcut)
+		parent: self groupName;
+		target: self;
+		label: 'Shortcut for ' , self settingLabel uncapitalized;
+		domainValues: self shortcutDomainValues;
+		default:
+			(BlocSpaceShortcutTool shortcutDomainValues at: self defaultIndex)
+				value;
+		description: 'Choose a shortcut.'
+]
+
+{ #category : #settings }
+BlocSpaceShortcutTool class >> settingsRootOn: aBuilder [
+
+	<systemsettings>
+	(aBuilder group: self rootGroupSymbol)
+		label: 'Bloc Space Tools';
+		description: 'Bloc Space Tools settings';
+		parent: Bloc groupSymbolForBloc;
+		order: 9;
+		with: [
+				BlocSpaceShortcutTool subclasses do: [ :each |
+						each settingOn: aBuilder ] ]
+]
+
+{ #category : #accessing }
+BlocSpaceShortcutTool class >> shortcut [
+
+	^ shortcut
+]
+
+{ #category : #accessing }
+BlocSpaceShortcutTool class >> shortcut: anObject [
+
+	shortcut := anObject
+]
+
+{ #category : #configuration }
+BlocSpaceShortcutTool class >> shortcutActionOn: aBlSpace [
+
+	self explicitRequirement
+]
+
+{ #category : #defaults }
+BlocSpaceShortcutTool class >> shortcutDomainValues [
+
+	^ shortcutDomainValues ifNil: [
+			  shortcutDomainValues := {
+				                          ('F1' -> KeyboardKey F1).
+				                          ('F2' -> KeyboardKey F2).
+				                          ('F3' -> KeyboardKey F3).
+				                          ('F4' -> KeyboardKey F4).
+				                          ('F5' -> KeyboardKey F5).
+				                          ('F6' -> KeyboardKey F6).
+				                          ('F7' -> KeyboardKey F7).
+				                          ('F8' -> KeyboardKey F8).
+				                          ('F9' -> KeyboardKey F9).
+				                          ('F10' -> KeyboardKey F10).
+				                          ('F11' -> KeyboardKey F11).
+				                          ('F12' -> KeyboardKey F12) } ]
+]
+
+{ #category : #'see class side' }
+BlocSpaceShortcutTool >> seeClassSide [ 
+]

--- a/src/Bloc-Text/BlTextStylerLauncher.class.st
+++ b/src/Bloc-Text/BlTextStylerLauncher.class.st
@@ -30,12 +30,15 @@ BlTextStylerLauncher class >> minTextSizeForStylingInBackground: anInteger [
 
 { #category : #accessing }
 BlTextStylerLauncher class >> settingsOn: aBuilder [
+
 	<systemsettings>
 	(aBuilder setting: #minTextSizeForStylingInBackground)
 		target: self;
 		parent: #Bloc;
 		default: 4000;
-		description: 'Set the minimum text size imposed to allow background styling';
+		order: 8;
+		description:
+			'Set the minimum text size imposed to allow background styling';
 		label: 'Min text size for background styling'
 ]
 

--- a/src/Bloc/BlSpace.class.st
+++ b/src/Bloc/BlSpace.class.st
@@ -1155,7 +1155,11 @@ BlSpace >> initialize [
 
 	self currentCursor: Cursor normal.
 
-	self root space: self
+	self root space: self.
+
+	"Install the Bloc Space Tools. See the class #BlocSpaceTools"
+	BlocSpaceShortcutTool subclassesDo: [ :each |
+		each addShortcutOn: self ]
 ]
 
 { #category : #'focus managing' }

--- a/src/Bloc/Bloc.class.st
+++ b/src/Bloc/Bloc.class.st
@@ -1,8 +1,22 @@
 "
-I represent bloc setting that can be customised from Menu > Settings.
+I represent bloc settings and world menu.
 
+# Settings
+The settings can accessible from Pharo > Settings.
 I allow users to:
  - manually select preferable BlHost
+ - manually select a renderer
+ - manually select an event handler registery type
+ - manually select a children data structure type
+ - enable or disable the Bloc's Assertions
+ - enable or disable the Debug Mode for Album and BlInfiniteElement
+ - manually set the minimum text size imposed to allow background styling
+
+# World Menu
+The world menu can be accessible from Library > Bloc.
+I allow users to:
+ - open the Bloc demo browser
+ - open the github page
 
 "
 Class {


### PR DESCRIPTION
See: #829 

I added settings system to add shortcuts to all BlSpace.

Currently I added 2 shortcuts:
F1 -> Open an inspector.
F2 -> Open a statistics window.

The system can be extended by subclassing `BlocSpaceShortcutTool`.

<img width="1042" height="737" alt="image" src="https://github.com/user-attachments/assets/7c0f4784-a58d-481b-8651-360b99d6c8d3" />

<img width="1750" height="807" alt="image" src="https://github.com/user-attachments/assets/871a8ae5-2bec-41a3-bfd4-6a23c715794f" />
